### PR TITLE
Replace hardcoded VERSION with importlib.metadata

### DIFF
--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
 from shutil import which
 
 import click
@@ -43,7 +44,11 @@ class Kospex:
     kospex core functionality
     """
 
-    VERSION = "0.0.35"  # This value should align with the pyproject.toml version for pip
+    try:
+        VERSION = version("kospex")
+    except PackageNotFoundError:
+        # Fallback if kospex is not installed as a package (e.g. running from source without install)
+        VERSION = "unknown"
 
     def __init__(self):
         self.original_cwd = None


### PR DESCRIPTION
Fixes #92.

Previously `kospex_core.py` had `VERSION = "0.0.35"` hardcoded which had to be manually kept in sync with `pyproject.toml`. This caused 0.0.36 to be released with `kospex --version` reporting 0.0.35.

Now VERSION is read from `importlib.metadata.version("kospex")` so pyproject.toml is the single source of truth. Falls back to `"unknown"` if kospex is not installed as a package.

## Note on editable installs

Editable installs (`pip install -e .`) cache the version at install time, so bumping `pyproject.toml` requires a reinstall for the new version to appear. This is expected behavior for editable installs.

## Testing

- All 191 tests pass locally
- `kospex --version` now correctly reports `0.0.36` after reinstall