### PR TITLE
krunner osi: pnpm-lock.yaml SCA support via new pnpm extractor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "duckdb==1.4.3",
     "prettytable==3.17.0",
     "dateutils",
-    "panopticas==0.0.15",
+    "panopticas==0.0.16",
     "python-dotenv",
     "sqlite-utils",
     "requests==2.33.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mergedeep==1.3.4
 mkdocs==1.6.1
 mkdocs-get-deps==0.2.2
 packaging==26.2
-panopticas==0.0.15
+panopticas==0.0.16
 pathspec==1.1.1
 platformdirs==4.9.6
 pluggy==1.6.0

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -53,13 +53,33 @@ def _template():
 
 
 def _split_at_key(key):
-    """Stub — implemented in 3.2."""
-    raise NotImplementedError
+    """v6/v9 ``packages:`` key → (name, version).
+
+    Handles the v6 leading ``/``, the v9 no-slash form, scoped names
+    (``@scope/name`` — the ``@`` that is *not* the version separator),
+    and the ``(peer@x)`` peer-dependency suffix.
+    """
+    key = key.lstrip("/")
+    key = key.split("(", 1)[0]
+    name, sep, version = key.rpartition("@")
+    if not sep or not name:
+        return None, None
+    return name, version
 
 
 def _split_v5_key(key):
-    """Stub — implemented in 3.2."""
-    raise NotImplementedError
+    """v5.x ``packages:`` key → (name, version).
+
+    v5 separates name and version with ``/`` (not ``@``); scoped names
+    keep their ``@scope/`` prefix. Peer suffix is ``_peer@x`` on the
+    version segment.
+    """
+    key = key.lstrip("/")
+    name, sep, version = key.rpartition("/")
+    if not sep or not name:
+        return None, None
+    version = version.split("_", 1)[0]
+    return name, version
 
 
 def _collect_direct_dev(doc):

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -83,8 +83,29 @@ def _split_v5_key(key):
 
 
 def _collect_direct_dev(doc):
-    """Stub — implemented in 3.3."""
-    raise NotImplementedError
+    """Return (direct_names, dev_names) sets.
+
+    Scans every importer's dep blocks (workspace/v9) plus top-level dep
+    blocks (non-workspace/v5). Works whether a block maps name→scalar
+    (v5) or name→{specifier, version} (v6/v9) — only the keys matter.
+    """
+    direct, dev = set(), set()
+
+    def _names(block):
+        return set(block.keys()) if isinstance(block, dict) else set()
+
+    sources = []
+    importers = doc.get("importers")
+    if isinstance(importers, dict):
+        sources.extend(v for v in importers.values() if isinstance(v, dict))
+    sources.append(doc)
+
+    for src in sources:
+        direct |= _names(src.get("dependencies"))
+        direct |= _names(src.get("optionalDependencies"))
+        dev |= _names(src.get("devDependencies"))
+
+    return direct, dev
 
 
 def extract_pnpm_lock(path):

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -136,9 +136,14 @@ def extract_pnpm_lock(path):
         return []
 
     lv = str(doc.get("lockfileVersion", "")).strip()
-    if lv.startswith("5"):
+    # v5.x: "5", "5.0", "5.1", "5.2", "5.3", "5.4" etc.
+    # v6.x: "6.0" etc.
+    # v9.x: "9.0" etc.
+    # Distinguish by major version only — split on "." and check first digit.
+    lv_major = lv.split(".")[0]
+    if lv_major == "5":
         splitter = _split_v5_key
-    elif lv.startswith("6") or lv.startswith("9"):
+    elif lv_major in ("6", "9"):
         splitter = _split_at_key
     else:
         logger.warning("Unknown pnpm lockfileVersion %r in %s", lv, path)

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -131,6 +131,9 @@ def extract_pnpm_lock(path):
     except FileNotFoundError:
         logger.warning("File not found: %s", path)
         return []
+    except (OSError, UnicodeDecodeError) as e:
+        logger.warning("Could not read pnpm-lock.yaml %s: %s", path, e)
+        return []
 
     if not doc or not isinstance(doc, dict):
         return []

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -1,0 +1,72 @@
+"""Extractor for pnpm-lock.yaml lockfiles.
+
+Returns one record per resolved package (the full dependency closure),
+shaped to KospexDependencies.get_package_template() so ``krunner osi``
+consumes the records unchanged. Design:
+deploy-kospex/planning/pnpm-extractor-osi-plan.md.
+
+pnpm publishes a per-lockfileVersion spec at github.com/pnpm/spec
+(lockfile/{5,5.2,6.0,9.0}.md). Three structurally distinct families:
+
+- v5.x  — ``packages:`` keyed ``/name/version`` (path style; scoped
+          ``/@scope/name/version``); peer suffix ``_peer@x``.
+- v6.0  — ``packages:`` keyed ``/name@version`` (scoped
+          ``/@scope/name@version``); peer suffix ``(peer@x)``.
+- v9.0  — ``packages:`` keyed ``name@version`` (no leading ``/``;
+          YAML-quoted when scoped — yaml.safe_load returns it
+          unquoted); resolved graph split into a separate
+          ``snapshots:`` section we ignore; peer suffix ``(peer@x)``.
+
+Integrity/checksum hashes are intentionally dropped — SCA does not
+consume them (producing checksum-bearing SBOMs is the out-of-scope
+"generator" category). On missing / invalid / unknown-lockfileVersion
+files we log a warning and return [] (extractors package convention).
+"""
+
+import yaml
+
+from kospex_utils import get_kospex_logger
+
+logger = get_kospex_logger("extractors.pnpm")
+
+
+def _template():
+    """Local copy of KospexDependencies.get_package_template()'s shape.
+
+    Duplicated (not imported) to keep this extractor pure — it must not
+    depend on the KospexDependencies / DB stack. A contract test
+    (test_template_matches_get_package_template) fails if the two drift.
+    """
+    return {
+        "package_name": "",
+        "package_version": "",
+        "version_type": "",
+        "_repo_id": "",
+        "file_path": "",
+        "requirements_type": "",
+        "extras": "",
+        "ecosystem": "",
+        "versions_behind": "",
+        "advisories": "",
+        "published_at": "",
+    }
+
+
+def _split_at_key(key):
+    """Stub — implemented in 3.2."""
+    raise NotImplementedError
+
+
+def _split_v5_key(key):
+    """Stub — implemented in 3.2."""
+    raise NotImplementedError
+
+
+def _collect_direct_dev(doc):
+    """Stub — implemented in 3.3."""
+    raise NotImplementedError
+
+
+def extract_pnpm_lock(path):
+    """Stub — implemented in 3.5."""
+    raise NotImplementedError

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -109,5 +109,63 @@ def _collect_direct_dev(doc):
 
 
 def extract_pnpm_lock(path):
-    """Stub — implemented in 3.5."""
-    raise NotImplementedError
+    """Parse a pnpm-lock.yaml; return get_package_template-shaped
+    records for the full resolved package closure.
+
+    Args:
+        path: Path to a pnpm-lock.yaml on disk.
+
+    Returns:
+        list[dict]: one record per distinct resolved ``name@version``
+        (no dedup — diamond deps yield one record per version), with
+        ``package_name``, ``package_version``, ``ecosystem="npm"`` and
+        ``requirements_type`` ("direct" / "dev" / "resolved"). Empty
+        list on missing / invalid / unknown-lockfileVersion files.
+    """
+    try:
+        with open(path) as f:
+            doc = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        logger.warning("Error parsing pnpm-lock.yaml %s: %s", path, e)
+        return []
+    except FileNotFoundError:
+        logger.warning("File not found: %s", path)
+        return []
+
+    if not doc or not isinstance(doc, dict):
+        return []
+
+    lv = str(doc.get("lockfileVersion", "")).strip()
+    if lv.startswith("5"):
+        splitter = _split_v5_key
+    elif lv.startswith("6") or lv.startswith("9"):
+        splitter = _split_at_key
+    else:
+        logger.warning("Unknown pnpm lockfileVersion %r in %s", lv, path)
+        return []
+
+    packages = doc.get("packages")
+    if not isinstance(packages, dict):
+        return []
+
+    direct, dev = _collect_direct_dev(doc)
+
+    records = []
+    for key in packages:
+        name, version = splitter(key)
+        if not name or not version:
+            continue
+        if name in direct:
+            req_type = "direct"
+        elif name in dev:
+            req_type = "dev"
+        else:
+            req_type = "resolved"
+        rec = _template()
+        rec["package_name"] = name
+        rec["package_version"] = version
+        rec["ecosystem"] = "npm"
+        rec["requirements_type"] = req_type
+        records.append(rec)
+
+    return records

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -28,6 +28,7 @@ from kospex_git import KospexGit
 from kospex_utils import KospexTimer
 from kospex.assessment_types import AssessmentTypes
 from kospex.extractors.workflows import extract_workflow_actions
+from kospex.extractors.pnpm import extract_pnpm_lock
 
 # Initialize Kospex environment with logging
 KospexUtils.init(create_directories=True, setup_logging=True, verbose=False)
@@ -640,6 +641,16 @@ def osi(all, request_id):
                         style="yellow",
                     )
                     continue
+                for req in reqs:
+                    req["_repo_id"] = r["_repo_id"]
+                    req["file_path"] = d["Provider"]
+                    req["ecosystem"] = "NPM"
+                    results.append(req)
+                console.log(reqs)
+
+            elif "pnpm-lock.yaml" in d["Provider"]:
+                console.print(f"Should parse pnpm-lock.yaml {d['Provider']}", style="blue")
+                reqs = extract_pnpm_lock(full_path)
                 for req in reqs:
                     req["_repo_id"] = r["_repo_id"]
                     req["file_path"] = d["Provider"]

--- a/tests/fixtures/pnpm/malformed.yaml
+++ b/tests/fixtures/pnpm/malformed.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+packages:
+  : : :
+  - not
+    valid

--- a/tests/fixtures/pnpm/no-packages.yaml
+++ b/tests/fixtures/pnpm/no-packages.yaml
@@ -1,0 +1,3 @@
+lockfileVersion: '6.0'
+importers:
+  .: {}

--- a/tests/fixtures/pnpm/unknown-version.yaml
+++ b/tests/fixtures/pnpm/unknown-version.yaml
@@ -1,0 +1,4 @@
+lockfileVersion: '99.0'
+packages:
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-abc}

--- a/tests/fixtures/pnpm/v5-simple.yaml
+++ b/tests/fixtures/pnpm/v5-simple.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: 5.4
+
+dependencies:
+  lodash: 4.17.21
+
+devDependencies:
+  jest: 29.0.0
+
+packages:
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-abc}
+    dev: false
+
+  /jest/29.0.0:
+    resolution: {integrity: sha512-def}
+    dev: true
+
+  /@babel/core/7.12.0:
+    resolution: {integrity: sha512-ghi}
+    dev: true
+
+  /react-dom/16.8.0_react@16.8.0:
+    resolution: {integrity: sha512-jkl}
+    dev: false

--- a/tests/fixtures/pnpm/v6-simple.yaml
+++ b/tests/fixtures/pnpm/v6-simple.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '6.0'
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      jest:
+        specifier: ^29.0.0
+        version: 29.0.0
+
+packages:
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-abc}
+    dev: false
+
+  /jest@29.0.0:
+    resolution: {integrity: sha512-def}
+    dev: true
+
+  /@babel/core@7.21.3:
+    resolution: {integrity: sha512-ghi}
+    dev: true
+
+  /@apideck/better-ajv-errors@0.3.6(ajv@8.12.0):
+    resolution: {integrity: sha512-jkl}
+    dev: true

--- a/tests/fixtures/pnpm/v9-simple.yaml
+++ b/tests/fixtures/pnpm/v9-simple.yaml
@@ -1,0 +1,33 @@
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      jest:
+        specifier: ^29.0.0
+        version: 29.0.0
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-abc}
+
+  jest@29.0.0:
+    resolution: {integrity: sha512-def}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-ghi}
+
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-old}
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-new}
+
+snapshots:
+
+  lodash@4.17.21: {}

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -179,3 +179,13 @@ class TestErrorHandling:
     def test_non_dict_root_returns_empty(self, tmp_path):
         p = _write(tmp_path, "list.yaml", "- a\n- b\n")
         assert extract_pnpm_lock(p) == []
+
+    def test_directory_path_returns_empty(self, tmp_path):
+        # opening a directory raises IsADirectoryError (an OSError subclass)
+        assert extract_pnpm_lock(str(tmp_path)) == []
+
+    def test_binary_content_returns_empty(self, tmp_path):
+        # non-UTF-8 bytes under a .yaml name raise UnicodeDecodeError on read
+        p = tmp_path / "binary.yaml"
+        p.write_bytes(b"\xff\xfe\x00\x01\x02\x03")
+        assert extract_pnpm_lock(str(p)) == []

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -157,3 +157,25 @@ class TestExtractV5:
         idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v5-simple.yaml")))
         assert idx[("lodash", "4.17.21")]["requirements_type"] == "direct"
         assert idx[("jest", "29.0.0")]["requirements_type"] == "dev"
+
+
+class TestErrorHandling:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert extract_pnpm_lock(str(tmp_path / "nope.yaml")) == []
+
+    def test_invalid_yaml_returns_empty(self):
+        assert extract_pnpm_lock(str(FIXTURES / "malformed.yaml")) == []
+
+    def test_unknown_lockfile_version_returns_empty(self):
+        assert extract_pnpm_lock(str(FIXTURES / "unknown-version.yaml")) == []
+
+    def test_no_packages_section_returns_empty(self):
+        assert extract_pnpm_lock(str(FIXTURES / "no-packages.yaml")) == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        p = _write(tmp_path, "empty.yaml", "")
+        assert extract_pnpm_lock(p) == []
+
+    def test_non_dict_root_returns_empty(self, tmp_path):
+        p = _write(tmp_path, "list.yaml", "- a\n- b\n")
+        assert extract_pnpm_lock(p) == []

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -71,3 +71,37 @@ class TestSplitHelpers:
 
     def test_v5_garbage_returns_none(self):
         assert _split_v5_key("nosuchslash") == (None, None)
+
+
+class TestCollectDirectDev:
+    """direct/dev name sets from importers + top-level dep blocks."""
+
+    def test_v6_importer_root_dependencies(self):
+        doc = {
+            "importers": {
+                ".": {
+                    "dependencies": {"lodash": {"specifier": "^4", "version": "4.17.21"}},
+                    "devDependencies": {"jest": {"specifier": "^29", "version": "29.0.0"}},
+                }
+            }
+        }
+        direct, dev = _collect_direct_dev(doc)
+        assert direct == {"lodash"}
+        assert dev == {"jest"}
+
+    def test_v5_top_level_scalar_deps(self):
+        doc = {
+            "dependencies": {"lodash": "4.17.21"},
+            "devDependencies": {"jest": "29.0.0"},
+        }
+        direct, dev = _collect_direct_dev(doc)
+        assert direct == {"lodash"}
+        assert dev == {"jest"}
+
+    def test_optional_deps_count_as_direct(self):
+        doc = {"optionalDependencies": {"fsevents": "2.3.2"}}
+        direct, dev = _collect_direct_dev(doc)
+        assert direct == {"fsevents"}
+
+    def test_missing_blocks_yield_empty_sets(self):
+        assert _collect_direct_dev({}) == (set(), set())

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -31,3 +31,43 @@ class TestTemplateContract:
         assert set(_template().keys()) == set(
             KospexDependencies().get_package_template().keys()
         )
+
+
+class TestSplitHelpers:
+    """Name/version extraction from packages: keys, per lockfile family."""
+
+    def test_at_key_unscoped_v6_leading_slash(self):
+        assert _split_at_key("/lodash@4.17.21") == ("lodash", "4.17.21")
+
+    def test_at_key_scoped_v6(self):
+        assert _split_at_key("/@babel/core@7.21.3") == ("@babel/core", "7.21.3")
+
+    def test_at_key_v6_peer_suffix_stripped(self):
+        assert _split_at_key("/@apideck/better-ajv-errors@0.3.6(ajv@8.12.0)") == (
+            "@apideck/better-ajv-errors",
+            "0.3.6",
+        )
+
+    def test_at_key_v9_no_leading_slash(self):
+        assert _split_at_key("@alloc/quick-lru@5.2.0") == ("@alloc/quick-lru", "5.2.0")
+
+    def test_at_key_v9_unscoped(self):
+        assert _split_at_key("lodash@4.17.21") == ("lodash", "4.17.21")
+
+    def test_at_key_garbage_returns_none(self):
+        assert _split_at_key("no-at-sign-here") == (None, None)
+
+    def test_v5_unscoped(self):
+        assert _split_v5_key("/lodash/4.17.21") == ("lodash", "4.17.21")
+
+    def test_v5_scoped(self):
+        assert _split_v5_key("/@babel/core/7.12.0") == ("@babel/core", "7.12.0")
+
+    def test_v5_peer_suffix_stripped(self):
+        assert _split_v5_key("/react-dom/16.8.0_react@16.8.0") == (
+            "react-dom",
+            "16.8.0",
+        )
+
+    def test_v5_garbage_returns_none(self):
+        assert _split_v5_key("nosuchslash") == (None, None)

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -105,3 +105,55 @@ class TestCollectDirectDev:
 
     def test_missing_blocks_yield_empty_sets(self):
         assert _collect_direct_dev({}) == (set(), set())
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "pnpm"
+
+
+def _by_name(records):
+    return {(r["package_name"], r["package_version"]): r for r in records}
+
+
+class TestExtractV6:
+    def test_v6_resolved_closure(self):
+        recs = extract_pnpm_lock(str(FIXTURES / "v6-simple.yaml"))
+        idx = _by_name(recs)
+        assert ("lodash", "4.17.21") in idx
+        assert ("jest", "29.0.0") in idx
+        assert ("@babel/core", "7.21.3") in idx
+        assert ("@apideck/better-ajv-errors", "0.3.6") in idx
+        for r in recs:
+            assert r["ecosystem"] == "npm"
+
+    def test_v6_classification(self):
+        idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v6-simple.yaml")))
+        assert idx[("lodash", "4.17.21")]["requirements_type"] == "direct"
+        assert idx[("jest", "29.0.0")]["requirements_type"] == "dev"
+        assert idx[("@babel/core", "7.21.3")]["requirements_type"] == "resolved"
+
+
+class TestExtractV9:
+    def test_v9_resolved_closure_and_dupes(self):
+        idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v9-simple.yaml")))
+        assert ("@alloc/quick-lru", "5.2.0") in idx
+        # same package, two versions → two distinct records, no dedup
+        assert ("@esbuild/aix-ppc64", "0.23.1") in idx
+        assert ("@esbuild/aix-ppc64", "0.27.0") in idx
+
+    def test_v9_classification(self):
+        idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v9-simple.yaml")))
+        assert idx[("lodash", "4.17.21")]["requirements_type"] == "direct"
+        assert idx[("jest", "29.0.0")]["requirements_type"] == "dev"
+
+
+class TestExtractV5:
+    def test_v5_resolved_closure(self):
+        idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v5-simple.yaml")))
+        assert ("lodash", "4.17.21") in idx
+        assert ("@babel/core", "7.12.0") in idx
+        assert ("react-dom", "16.8.0") in idx  # peer suffix stripped
+
+    def test_v5_classification(self):
+        idx = _by_name(extract_pnpm_lock(str(FIXTURES / "v5-simple.yaml")))
+        assert idx[("lodash", "4.17.21")]["requirements_type"] == "direct"
+        assert idx[("jest", "29.0.0")]["requirements_type"] == "dev"

--- a/tests/test_extractors_pnpm.py
+++ b/tests/test_extractors_pnpm.py
@@ -1,0 +1,33 @@
+"""Tests for the pnpm-lock.yaml extractor.
+
+Mirrors tests/test_extractors_workflows.py structure: helper-level
+tests, extract-level tests per lockfileVersion, classification, and
+error handling.
+"""
+from pathlib import Path
+
+import pytest
+
+from kospex.extractors.pnpm import (
+    extract_pnpm_lock,
+    _split_at_key,
+    _split_v5_key,
+    _collect_direct_dev,
+    _template,
+)
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content)
+    return str(p)
+
+
+class TestTemplateContract:
+    """The local record template must stay in sync with KospexDependencies."""
+
+    def test_template_matches_get_package_template(self):
+        from kospex_dependencies import KospexDependencies
+        assert set(_template().keys()) == set(
+            KospexDependencies().get_package_template().keys()
+        )


### PR DESCRIPTION
## Summary

pnpm projects currently produce **zero** `krunner osi` SCA results — `pnpm-lock.yaml` was neither detected nor parsed. This adds end-to-end support:

- **New `src/kospex/extractors/pnpm.py`** — a pure file-in/records-out parser for `pnpm-lock.yaml`, handling all three structurally distinct lockfile families (`lockfileVersion` 5.x path-style keys, 6.0 `/name@version`, 9.0 `name@version` + separate `snapshots:`). Emits `get_package_template`-shaped records (`package_name`, `package_version`, `ecosystem="npm"`, `requirements_type` ∈ {direct, dev, resolved}). Mirrors the existing find-actions `extractors/workflows.py` precedent (module-level pure functions, no DB access). Warns and returns `[]` on missing / invalid / unknown-version / unreadable files — never raises.
- **`krunner osi`** gains a `pnpm-lock.yaml` branch mirroring the `package.json` branch (`ecosystem="NPM"`), consuming the extractor. `kospex_dependencies.py` is unchanged — the extractor is the parser.
- **panopticas pin → 0.0.16**, which adds `pnpm-lock.yaml` file-type detection (required for `osi` to surface the file).
- Tests + fixtures covering all three families, scoped (`@scope/name`) names, peer-suffix stripping, direct/dev/resolved classification, and the full error-handling matrix (missing file, invalid YAML, unknown lockfileVersion, no-packages, directory path, binary content).

## Test plan

- [x] 29 extractor unit tests + 34 existing workflow extractor tests pass (63 total)
- [x] Smoke-tested against real lockfiles — `chartjs/Chart.js` (v6, 2079 packages) and `tailwindlabs/tailwindcss` (v9, 619 packages): exact 1:1 lockfile-key → record fidelity, scoped names handled, `snapshots:` correctly ignored, no crashes
- [ ] Live `krunner osi <repo>` against a synced repo containing a `pnpm-lock.yaml` — not yet run; the downstream deps.dev enrichment loop is shared, unmodified code already exercised by the `package.json` path

## Notes / follow-ups (non-blocking)

- Packages resolved from **non-npm-registry sources** (git / `link:` / `workspace:` / `jsr:`) are currently emitted as `ecosystem=npm` like all other entries, so they'll yield "Unknown" deps.dev enrichment rather than erroring. Intentionally deferred — the same protocol handling applies to the yarn lockfile extractor and will be addressed alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)