### PR TITLE
Render kospex summary with rich + status legend

### DIFF
--- a/changes/202605-summary-rich-status-legend.md
+++ b/changes/202605-summary-rich-status-legend.md
@@ -30,8 +30,11 @@ the existing defaults; the legend reflects these.
     `rich.table.Table`. Add a module-level `Console`. Numeric columns
     right-justified, `repo`/`status` left.
   - `PrettyTable` auto-sorts by `last_commit`; `rich` does not, so the
-    `results` list is sorted by `last_commit` before rows are added, preserving
-    current ordering.
+    `results` list is sorted by `last_commit` (ascending) before rows are added,
+    preserving current ordering. The sort key is `None`-safe (rows with a missing
+    `last_commit` sort to the tail).
+  - Cell values are coerced with `"" if v is None else str(v)` so empty cells
+    render blank rather than the literal `"None"`.
   - The other `PrettyTable` usages in this file are left untouched.
 
 - **`src/kospex_utils.py`**
@@ -56,6 +59,11 @@ the existing defaults; the legend reflects these.
 - No data/logic changes — rendering only. Status thresholds, CSV output, and
   returned `results` are unchanged.
 - No colour-coding in this change (plain legend); can be added later.
+- Rendering width: `rich` fits the table to the detected terminal width. In an
+  interactive terminal the full repo table shows; when output is piped to a
+  narrow (80-col) non-tty, `rich` ellipsizes long `repo_id`s and dates (the old
+  `PrettyTable` always emitted full width). Use the `-out` CSV option for
+  machine-consumable output.
 
 ## Testing
 

--- a/src/kospex_cli.py
+++ b/src/kospex_cli.py
@@ -305,11 +305,12 @@ def summary(
         print(f"\nSummary of {len(results)} repositories found.\n")
 
         # Print status stats of the repos found
-        print("Repo status summary")
+        console.print("Repo status summary")
         status = KospexUtils.count_key_occurrences(results, "status")
         status_table = KospexUtils.get_status_table(status)
-        print(status_table)
-        print()
+        console.print(status_table)
+        console.print(KospexUtils.get_status_legend())
+        console.print()
 
         unknown = 0
         repo_dirs = []
@@ -334,7 +335,7 @@ def summary(
             # print(records)
             docker_status = KospexUtils.count_key_occurrences(records, "status")
             docker_status_table = KospexUtils.get_status_table(docker_status)
-            print(docker_status_table)
+            console.print(docker_status_table)
 
         if dependencies:
             kdeps = KospexDependencies(kospex_db=kospex.kospex_db, kospex_query=kospex.kospex_query)
@@ -346,8 +347,8 @@ def summary(
             records = KospexUtils.get_all_last_commit_info(deps)
             dep_stats = KospexUtils.repo_stats(records, "author_date")
             deps_status_table = KospexUtils.get_status_table(dep_stats)
-            print("\nDependencies summary")
-            print(deps_status_table)
+            console.print("\nDependencies summary")
+            console.print(deps_status_table)
 
         print()
 
@@ -634,7 +635,7 @@ def deps(repo, file, directory, out, dev):
             print("\nOverall Summary of dependency files found")
             print(stats)
             status_table = KospexUtils.get_status_table(stats)
-            print(status_table)
+            console.print(status_table)
 
             print("\nSummary of dependency files found in the directory by repo\n")
             status_table = KospexUtils.get_repo_stats_table(stats=stats_dict)

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -15,6 +15,8 @@ import click
 # from kospex_mergestat import KospexMergeStat
 import panopticas
 from prettytable import PrettyTable, from_db_cursor
+from rich.console import Console as RichConsole
+from rich.table import Table as RichTable
 from sqlite_utils import Database
 
 import kospex_schema as KospexSchema
@@ -23,6 +25,8 @@ from kospex.db.introspect import get_kospex_tables
 from kospex_dependencies import KospexDependencies
 from kospex_git import KospexGit, MissingGitDirectory
 from kospex_query import KospexData, KospexQuery
+
+_console = RichConsole()
 
 
 class GitRepo(click.ParamType):
@@ -414,7 +418,6 @@ class Kospex:
         )
         print()
 
-        table = PrettyTable()
         headers = [
             "repo",
             "status",
@@ -427,20 +430,11 @@ class Kospex:
             "commits",
         ]
 
-        # table.field_names = ["repo", "status", "last_commit",
-        #                     "first_commit", "developers", "commits", "active", "present"]
-
-        table.field_names = headers
-        table.align["repo"] = "l"
-        table.align["status"] = "l"
-        table.align["last_commit"] = "r"
-        table.align["first_commit"] = "r"
-        table.align["active_days"] = "r"
-        table.align["developers"] = "r"
-        table.align["commits"] = "r"
-        table.align["active"] = "r"
-        table.align["present"] = "r"
-        table.sortby = "last_commit"
+        left_cols = {"repo", "status"}
+        table = RichTable()
+        for header in headers:
+            justify = "left" if header in left_cols else "right"
+            table.add_column(header, justify=justify)
 
         results = []
 
@@ -503,8 +497,6 @@ class Kospex:
                 row["last_commit"], row["first_commit"]
             )
 
-            table.add_row(KospexUtils.get_values_by_keys(row, headers))
-
             if repo := repoid_lookup.get(row["repo"]):
                 row["git_url"] = repo.get("git_remote")
                 row["file_path"] = repo.get("file_path")
@@ -514,21 +506,17 @@ class Kospex:
 
             results.append(row)
 
+        # rich does not auto-sort; replicate PrettyTable's sortby="last_commit"
+        results.sort(key=lambda r: (r.get("last_commit") is None, r.get("last_commit")))
+        for row in results:
+            table.add_row(*[str(v) for v in KospexUtils.get_values_by_keys(row, headers)])
+
         if results_file:
             KospexUtils.list_dict_2_csv(results, results_file)
             print("Writing CSV results to file: " + results_file)
 
-        if table.rows:
-            print(table)
-            # print(KospexUtils.count_key_occurrences(results, "status"))
-        #    status = KospexUtils.count_key_occurrences(results, "status")
-        #    status_table = KospexUtils.get_status_table(status)
-        #    print()
-        # print(status_table)
-        #    print()
-
-        # else:
-        #    print("No repositories found in the kospex DB\n")
+        if results:
+            _console.print(table)
 
         return results
 

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -509,7 +509,9 @@ class Kospex:
         # rich does not auto-sort; replicate PrettyTable's sortby="last_commit"
         results.sort(key=lambda r: (r.get("last_commit") is None, r.get("last_commit")))
         for row in results:
-            table.add_row(*[str(v) for v in KospexUtils.get_values_by_keys(row, headers)])
+            table.add_row(
+                *["" if v is None else str(v) for v in KospexUtils.get_values_by_keys(row, headers)]
+            )
 
         if results_file:
             KospexUtils.list_dict_2_csv(results, results_file)

--- a/src/kospex_utils.py
+++ b/src/kospex_utils.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone, timedelta
 from dateutil import parser
 from collections import Counter, OrderedDict
 from prettytable import PrettyTable
+from rich.table import Table as RichTable
 from dotenv import load_dotenv
 
 # Import centralized logging after other imports to handle potential import errors
@@ -1287,6 +1288,21 @@ def convert_to_percentage(data):
             percentage_data[key] = round(percentage, 2)
 
     return percentage_data
+
+def get_status_legend():
+    """Return a rich Table legend describing the development statuses.
+
+    Statuses come from development_status() with the default thresholds
+    (active_limit=90, aging_limit=180, stale_limit=365).
+    """
+    table = RichTable(title="Status legend", title_style="dim", show_edge=True)
+    table.add_column("Status", style="dim")
+    table.add_column("Meaning", style="dim")
+    table.add_row("Active", "commit within last 90 days")
+    table.add_row("Aging", "last commit 91-180 days ago")
+    table.add_row("Stale", "last commit 181-365 days ago")
+    table.add_row("Unmaintained", "no commit in over 365 days")
+    return table
 
 def get_status_table(status):
     """

--- a/src/kospex_utils.py
+++ b/src/kospex_utils.py
@@ -1306,8 +1306,9 @@ def get_status_legend():
 
 def get_status_table(status):
     """
-    Return a prettytable object for the status results ("Active", "Aging", "Stale", "Unmaintained").
-    The raw numbers are shown in the first row and the percentages in the second row.
+    Return a rich Table for the status results
+    ("Active", "Aging", "Stale", "Unmaintained").
+    Row 1 = raw counts, row 2 = percentages.
     """
 
     total = sum(status.values())
@@ -1315,18 +1316,15 @@ def get_status_table(status):
     # Need to run convert first, or the generic function
     # will include the percentage values in the calculation
     status["Total"] = total
-
     status_percentage["Total"] = 100
 
-    table = PrettyTable()
-    table.field_names = ["Active", "Aging", "Stale", "Unmaintained", "Total"]
-    values = [status.get(key,0) for key in table.field_names]
+    headers = ["Active", "Aging", "Stale", "Unmaintained", "Total"]
+    table = RichTable()
+    for header in headers:
+        table.add_column(header, justify="right")
 
-    table.add_row(values)
-
-    status_percentage["Total"] = 100
-    values = [ f"{status_percentage.get(key,0)}%" for key in table.field_names]
-    table.add_row(values)
+    table.add_row(*[str(status.get(key, 0)) for key in headers])
+    table.add_row(*[f"{status_percentage.get(key, 0)}%" for key in headers])
 
     return table
 

--- a/tests/test_kospex_utils.py
+++ b/tests/test_kospex_utils.py
@@ -22,3 +22,22 @@ def test_mailmap():
 
     results = KospexUtils.parse_mailmap(f"{HERE}/mailmap/github.com/adamtornhill/code-maat/.mailmap")
     print(results)
+
+def test_get_status_legend():
+    """get_status_legend returns a rich Table describing the 4 statuses."""
+    from rich.table import Table
+
+    legend = KospexUtils.get_status_legend()
+    assert isinstance(legend, Table)
+
+    from rich.console import Console
+    console = Console(width=120)
+    with console.capture() as capture:
+        console.print(legend)
+    text = capture.get()
+    for status in ["Active", "Aging", "Stale", "Unmaintained"]:
+        assert status in text
+    # thresholds appear in the descriptions
+    assert "90" in text
+    assert "180" in text
+    assert "365" in text

--- a/tests/test_kospex_utils.py
+++ b/tests/test_kospex_utils.py
@@ -41,3 +41,21 @@ def test_get_status_legend():
     assert "90" in text
     assert "180" in text
     assert "365" in text
+
+def test_get_status_table_rich():
+    """get_status_table returns a rich Table with counts and percentages."""
+    from rich.table import Table
+    from rich.console import Console
+
+    status = {"Active": 3, "Aging": 1, "Stale": 0, "Unmaintained": 1}
+    table = KospexUtils.get_status_table(status)
+    assert isinstance(table, Table)
+
+    console = Console(width=120)
+    with console.capture() as capture:
+        console.print(table)
+    text = capture.get()
+    for header in ["Active", "Aging", "Stale", "Unmaintained", "Total"]:
+        assert header in text
+    assert "5" in text       # total count
+    assert "%" in text       # percentage row present


### PR DESCRIPTION
## Summary
- Convert the `kospex summary` per-repo table (in `kospex_core.summary()`) from PrettyTable to a `rich.table.Table`, preserving columns and the `last_commit` ascending sort (None-safe).
- Convert the shared status-count table (`kospex_utils.get_status_table()`) to rich; all `get_status_table` callers in `kospex_cli.py` now use `console.print`.
- Add `get_status_legend()` and print it below the status summary (summary command only), describing the four statuses: Active (≤90d), Aging (91–180d), Stale (181–365d), Unmaintained (>365d).

Rendering-only change — status thresholds, CSV (`-out`) output, and returned `results` are unchanged. Two new unit tests; full suite: 245 passed, 67 skipped.

Spec: `changes/202605-summary-rich-status-legend.md` · Plan: `docs/superpowers/plans/2026-05-23-summary-rich-status-legend.md`

Note: rich fits the table to terminal width and will ellipsize long repo_ids/dates when piped to a narrow non-tty; use `-out` for machine-consumable output.

## Test Plan
- [ ] `pytest` — green
- [ ] `kospex summary` in a normal-width terminal — repo table, status-count table, and "Status legend" all render as rich tables
- [ ] `kospex summary -dependencies` — dependencies status table renders as rich (no legend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)