### PR TITLE
file_metadata: one current-state row per file (+ version-aware sync guard)

### DIFF
--- a/changes/202606-file-metadata-single-row.md
+++ b/changes/202606-file-metadata-single-row.md
@@ -138,9 +138,15 @@ below. This is the runtime-data half of draft issue #20.
   `tests/test_metadata_rebuild_guard.py` (unit) + skip / panopticas-bump end-to-end in
   `tests/test_file_metadata_sync.py`. Also fixed a latent migrator transaction bug the
   first real migration exposed.
-- **[TODO]** Item 4 (truncate + re-sync cleanup on the real DB). The rename/path-mismatch
-  ~5% (files with no commit-map entry → HEAD-fallback hash, no date) is deferred per
-  prior decision.
+- **[DONE] Real-DB cleanup (item 4).** Applied `0003`, then force-rebuilt + pruned
+  `latest=0` for all 104 repos (49s). `file_metadata` went 144,645 → **74,016 rows**,
+  all `latest=1`; **0** providers with a duplicate `latest=1` row (was 94/95 repos);
+  0 `.git` rows; provenance stamped on 104/104 repos. `/osi/` dep-file rows now carry
+  `tech_type` **and** `committer_when` in one row. Rebuild used force (bypassing the
+  guard) since a bare truncate would leave stamped provenance and make the guard skip
+  an empty table.
+- **Deferred:** the rename/path-mismatch (~0.4% of rows: files with no commit-map entry
+  → HEAD-fallback hash, no date). Tracked as the next item on this feature's tail.
 
 ## Work items
 

--- a/changes/202606-file-metadata-single-row.md
+++ b/changes/202606-file-metadata-single-row.md
@@ -119,7 +119,21 @@ below. This is the runtime-data half of draft issue #20.
   lookup inside `file_metadata()` (~34s → ~1.4s on babel; verified identical output,
   0 mismatches). This is the cheap source of each file's last-commit hash + date that
   the single-row builder (item 1) consumes. Tests: `tests/test_latest_commit_file_map.py`.
-- **[TODO]** Work items 1–4 below.
+- **[DONE] Single-row builder (item 1) + committer_when for all files (item 2).**
+  `KospexSchema.build_file_metadata_rows()` merges panopticas (all files, incl
+  UNKNOWN) + scc metrics (where known) + the commit map into **one row per file**,
+  keyed by the per-file last-commit hash; `committer_when` is set for every committed
+  file. `file_metadata()` now does a single `reset latest=0` + merged upsert (was two
+  divergent upserts). Also fixed: `get_repo_files()` now excludes `.git/` explicitly
+  (panopticas didn't on freshly-init'd repos). Tests:
+  `tests/test_build_file_metadata_rows.py` (unit) +
+  `tests/test_file_metadata_sync.py` (end-to-end sync: one row per file + the
+  3-file churn invariant).
+- **[TODO]** Item 3 (version-aware guard + `0003` migration) and item 4 (truncate +
+  re-sync cleanup). Note: the existing HEAD-hash skip-guard still works in the common
+  case (a synced HEAD leaves ≥1 row at that hash), so it degrades gracefully until
+  item 3 rehomes it. The rename/path-mismatch ~5% (files with no commit-map entry →
+  HEAD-fallback hash, no date) is deferred per prior decision.
 
 ## Work items
 

--- a/changes/202606-file-metadata-single-row.md
+++ b/changes/202606-file-metadata-single-row.md
@@ -129,11 +129,18 @@ below. This is the runtime-data half of draft issue #20.
   `tests/test_build_file_metadata_rows.py` (unit) +
   `tests/test_file_metadata_sync.py` (end-to-end sync: one row per file + the
   3-file churn invariant).
-- **[TODO]** Item 3 (version-aware guard + `0003` migration) and item 4 (truncate +
-  re-sync cleanup). Note: the existing HEAD-hash skip-guard still works in the common
-  case (a synced HEAD leaves ≥1 row at that hash), so it degrades gracefully until
-  item 3 rehomes it. The rename/path-mismatch ~5% (files with no commit-map entry →
-  HEAD-fallback hash, no date) is deferred per prior decision.
+- **[DONE] Version-aware skip-guard (item 3).** `0003` adds the `repos` provenance
+  columns; `needs_metadata_rebuild()` decides rebuild-vs-skip from recorded vs current
+  (HEAD + `panopticas`/`scc` versions, compared as opaque strings); `file_metadata()`
+  reads the provenance, rebuilds only when needed, stamps it after a successful write,
+  and logs version transitions to disk via `KospexUtils.get_kospex_logger`. Degrades to
+  always-rebuild on a pre-0003 DB (columns absent). Tests:
+  `tests/test_metadata_rebuild_guard.py` (unit) + skip / panopticas-bump end-to-end in
+  `tests/test_file_metadata_sync.py`. Also fixed a latent migrator transaction bug the
+  first real migration exposed.
+- **[TODO]** Item 4 (truncate + re-sync cleanup on the real DB). The rename/path-mismatch
+  ~5% (files with no commit-map entry → HEAD-fallback hash, no date) is deferred per
+  prior decision.
 
 ## Work items
 
@@ -163,6 +170,13 @@ below. This is the runtime-data half of draft issue #20.
    - This closes the draft-#20 hole: a panopticas pin bump now forces a re-tag pass even
      when no commits landed, instead of silently serving stale `tech_type`. Because
      hashes are stable across a pure re-tag, that pass updates rows in place.
+   - **No version *history*, so log transitions to disk.** The `repos` columns are
+     point-in-time (each rebuild overwrites them) — they answer "what version is the
+     current tagging?" not "when did it change?". When the guard rebuilds because a tool
+     version changed, log it via `KospexUtils.get_kospex_logger(...)` (→ `~/kospex/logs/`)
+     with the repo, reason, and old→new versions. That gives a durable, greppable audit
+     trail without a schema for it. A queryable history (e.g. an `observations` row per
+     re-tag) is a possible future enhancement, not built now.
 4. **Data cleanup (DB preserved, only `file_metadata` rows are disposable).** Truncate
    `file_metadata` and re-sync repos under the fixed code. No row-level migration — the
    table is rebuildable from the repos + `commit_files`. Every other table is untouched.

--- a/changes/202606-file-metadata-single-row.md
+++ b/changes/202606-file-metadata-single-row.md
@@ -1,0 +1,194 @@
+# file_metadata — one current-state row per file (fix the multi-hash duplication)
+
+## Overview
+
+`file_metadata` is meant to answer one question: *"what files are in this repo as of
+the last sync, what are they (language/tags + scc metrics), and when was each last
+modified?"* — a **current-state** table. It is also the **only** table carrying
+panopticas `tech_type` / `Language`, which many other queries depend on
+(`/osi/`, tech-landscape, `find-actions`, dependency discovery).
+
+Today it is badly polluted: **94 of 95 repos have many commit hashes flagged
+`latest=1`** (apache/arrow: 1609, babel: 1540, react: 1190), when there should be
+exactly one current row per file. This plan fixes the writer so each file produces a
+single current-state row, and re-homes the one thing that depended on the broken
+behaviour.
+
+## The bug (evidence)
+
+Every file ends up with **two** `latest=1` rows under two different `hash` values.
+For `github.com~kospex~kospex`, `README.md`:
+
+| hash | committer_when | Lines/Code | tech_type | written by |
+|---|---|---|---|---|
+| `1c4fb6d` (repo HEAD) | `None` | `None` | `Markdown` (+ tags) | `metadata_rows_from_repo_files` |
+| `99c39e4` (file's last commit) | `2025-08-14` | `142`/`89` | (none) | scc enrichment loop |
+
+Repo-wide: 234 HEAD-hash rows carry scc metrics on only 4 files; the 222 per-file-hash
+rows carry metrics + `committer_when` on all of them. The two row-sets are
+complementary halves of what should be one row.
+
+## Root cause
+
+`KospexDependencies`… no — `Kospex.file_metadata()` (`src/kospex_core.py:920`) writes
+each file **twice**, keyed by different hashes:
+
+1. **`src/kospex_core.py:949-961`** — resets `latest=0` for the repo, then
+   `metadata_rows_from_repo_files()` (`src/kospex_schema.py:521`) upserts rows keyed by
+   the **repo HEAD hash** (`get_repo_files` sets `data["hash"] = self.current_hash`,
+   `src/kospex_git.py:564`). These rows carry `Language` + `tech_type`.
+2. **`src/kospex_core.py:1011-1042`** — the scc loop builds the same files, sets
+   `row["hash"] = git_hash` (HEAD) at `:1013`, then **`:1031` overwrites it** with
+   `commit_info.get("hash")` — the file's *own last-commit* hash — and upserts. These
+   rows carry scc metrics + `committer_when`, but no `tech_type`.
+
+Because `hash` is in the primary key `(Provider, hash, _repo_id)`, step 2 does not
+*enrich* step 1's rows — it inserts a **parallel set**. Both are `latest=1`.
+
+Git history confirms this is hangover: the `commit_files` lookup that supplies
+`committer_when` was added 2025-08 (`0553fb22`) to replace an expensive per-file git
+command; in doing so it also pulled the *hash* from `commit_files` and overrode the
+HEAD hash. The **date** was the goal; the **hash override** was the accident.
+
+Secondary defect: `metadata_rows_from_repo_files` (`src/kospex_schema.py:521`) appends
+`filtered_dict` *inside* the inner key loop, producing duplicate references to the same
+dict. Harmless (PK-dedup'd) but should be fixed in the rework.
+
+## Decided model (current-state, per-file hash, soft-delete)
+
+A clone + sync of a **never-seen** repo produces exactly:
+
+- **one `latest=1` row per file** currently in the working tree at HEAD;
+- columns: `Provider`/`Filename`, `Language` + `tech_type` (panopticas — full coverage
+  incl. its UNKNOWN default), scc metrics (`Lines`/`Code`/`Comments`/`Blanks`/
+  `Complexity`/`Bytes`) where scc knows the type, `committer_when` (last-commit date)
+  and `hash` (last-commit hash) **for every file**, `_git_*` / `_repo_id`;
+- row count = file count. No history rows on first sync.
+
+**Canonical `hash` = the file's last-commit hash** (not repo HEAD). Rationale agreed in
+design discussion:
+
+- HEAD hash repeated on every row is redundant — it's a single repo fact (belongs in
+  `repos`), carries no per-file signal.
+- Per-file hash is information-dense: each row says *which commit last touched this
+  file*, joinable to `commits`, and serves both current-state and change analysis.
+- It is the more multi-branch-resistant key (stable across branches for unchanged
+  files) — relevant to the multi-branch backlog.
+
+**History / churn is NOT this table's job.** `commit_files` already holds full
+per-file history; `/hotspots/` already derives "good enough" complexity (total commits,
+authors, file size) from commit data. So `file_metadata` stays current-state.
+
+**Soft-delete is fine** (confirmed): on re-sync, `reset latest=0` then upsert current
+files as `latest=1`. Files no longer present, and superseded file versions, simply
+remain as `latest=0` tombstones — not hard-deleted. `latest=1` = current files. Table
+growth is then bounded by *real churn*, not sync frequency (an unchanged file re-uses
+its PK and updates in place).
+
+### Invariant: a 3-file change churns 3 rows, not the whole repo
+
+panopticas and scc both scan the **whole** working tree every sync, so the rebuild
+*touches* every file — but it must **not** rewrite every file's `hash`. Each file's
+`hash` + `committer_when` come from `KospexQuery.latest_commit_file_map(repo_id)` (one
+windowed pass over `commit_files` — see Progress), **never** blanket-assigned the repo
+HEAD. So:
+
+- an **unchanged** file resolves to the *same* last-commit hash as last sync → same PK
+  `(Provider, hash, _repo_id)` → upsert is an in-place no-op (only `latest` flips
+  0→1);
+- only the **changed** files resolve to a new hash → new row.
+
+This is the protection the per-file-hash key buys; the failure mode to guard against is
+a regression that assigns HEAD to all files (the old behaviour). Locked by a test:
+sync a fixture, change N files, re-sync, assert exactly N new hashes/rows appear and the
+rest are untouched.
+
+### panopticas / scc version changes re-tag in place
+
+When panopticas (or scc) is upgraded it may classify the **same** file differently. The
+file's content — and therefore its last-commit hash — is unchanged, so the rebuild
+upserts the new `tech_type` / metrics onto the **same** row (one row, refreshed tag),
+no churn. The catch is *triggering* the rebuild at all: see the version-aware guard
+below. This is the runtime-data half of draft issue #20.
+
+## Progress
+
+- **[DONE] One-pass per-file commit map.** `KospexQuery.latest_commit_file_map(repo_id)`
+  returns `{file_path: {hash, committer_when}}` from a single windowed query over
+  `commit_files`, replacing the prior load-all-into-memory + unindexed-scan-per-file
+  lookup inside `file_metadata()` (~34s → ~1.4s on babel; verified identical output,
+  0 mismatches). This is the cheap source of each file's last-commit hash + date that
+  the single-row builder (item 1) consumes. Tests: `tests/test_latest_commit_file_map.py`.
+- **[TODO]** Work items 1–4 below.
+
+## Work items
+
+1. **Single row per file.** Rework `file_metadata()` so panopticas (all files, incl.
+   UNKNOWN, with `tech_type`/`Language`) and scc (metrics for known types) build **one**
+   row per file, keyed by the **per-file last-commit hash**, then a single
+   `reset latest=0` + `upsert latest=1`. Remove the HEAD-hash row-set; remove the
+   `:1031` override as a concept (the per-file hash becomes the row's only hash). Fix
+   the `metadata_rows_from_repo_files` inner-loop append bug.
+2. **`committer_when` for all files.** Populate last-commit date + hash from
+   `commit_files` for **every** file, not just scc-known ones (currently set only inside
+   the scc loop). This also repairs `/osi/`'s "days ago" (it reads
+   `get_dependency_files`, `src/kospex_query.py:238`, which today gets the HEAD-hash rows
+   whose `committer_when` is `None`).
+3. **Re-home the skip-guard, and make it version-aware.** The guard at
+   `src/kospex_core.py:931-937` decides "already synced this HEAD?" by looking for
+   HEAD-hash rows in `file_metadata` — which no longer exist after (1). Replace it with
+   columns on `repos` (DB migration `0003`): **`last_sync_hash`**,
+   **`last_panopticas_version`**, **`last_scc_version`**. Rebuild metadata when **any**
+   of: `current HEAD != last_sync_hash`, panopticas version changed, scc version
+   changed. Otherwise skip (the expensive whole-repo scan is the thing we're avoiding).
+   Stamp all three on a successful rebuild.
+
+   - panopticas version: `importlib.metadata.version("panopticas")`.
+   - scc version: parse `scc --version` (cache per run); if scc is absent, record null
+     and don't let its absence force rebuilds.
+   - This closes the draft-#20 hole: a panopticas pin bump now forces a re-tag pass even
+     when no commits landed, instead of silently serving stale `tech_type`. Because
+     hashes are stable across a pure re-tag, that pass updates rows in place.
+4. **Data cleanup (DB preserved, only `file_metadata` rows are disposable).** Truncate
+   `file_metadata` and re-sync repos under the fixed code. No row-level migration — the
+   table is rebuildable from the repos + `commit_files`. Every other table is untouched.
+
+## Files anticipated
+
+- `src/kospex_core.py` — `file_metadata()` rewrite (single row builder, per-file hash,
+  `committer_when` for all files); guard uses `repos.last_sync_hash`. Audit
+  `cli_file_metadata()` (`:825`) which shares the `metadata_rows_from_repo_files` path.
+- `src/kospex_schema.py` — fix `metadata_rows_from_repo_files()` (`:521`) append bug;
+  confirm column set.
+- `src/kospex_git.py` — `get_repo_files()` hash semantics (stop forcing
+  `self.current_hash` as the canonical file hash where the per-file hash is intended).
+- `src/kospex/db/migrations/0003_repos_sync_provenance.sql` — add `last_sync_hash`,
+  `last_panopticas_version`, `last_scc_version` to `repos`.
+- Tests (TDD): metadata sync of a small fixture repo asserts **exactly one `latest=1`
+  row per file**, `committer_when` populated for **all** files (incl. an scc-unknown
+  file); **3-file-change invariant** (change N files, re-sync, exactly N new hashes/rows,
+  rest untouched); **guard** skips a no-change re-sync, rebuilds on HEAD change, and
+  rebuilds (re-tagging in place) on a simulated panopticas-version bump.
+
+## Out of scope / backlog
+
+- **`file_metadata.authors` / `.commits`** (0/136k populated today) — keep the columns;
+  populate via a later sync/assessment pass for per-file complexity. Tracked:
+  deploy-kospex `planning/draft-issues.md` #23.
+- **Multi-branch** — once non-default branches are ingested, the `commit_files`
+  "last commit" lookup (`latest_commit_file_map`, `ORDER BY committer_when DESC`) needs
+  branch-awareness, and `latest`/`authors`/`commits` semantics need a branch dimension.
+  Separate design.
+- **Incremental scanning** — panopticas + scc still scan the *whole* working tree each
+  sync; the one-pass map only made the *commit lookup* cheap, not the *scan* itself.
+  Row churn is already bounded to changed files (per-file hash) and the version-aware
+  guard skips the scan entirely when nothing changed — so scanning only changed paths is
+  a *compute* optimization for later, not correctness.
+- Dropping any vestigial columns — not now.
+
+## Open questions
+
+- Exact home for `last_sync_hash` update (inside `file_metadata()` vs the higher-level
+  `sync_repo`) so it's only stamped after a *successful* metadata rebuild.
+- Whether `cli_file_metadata()` should be collapsed into the same single-row builder or
+  left as a thin display path.

--- a/changes/202606-file-metadata-single-row.md
+++ b/changes/202606-file-metadata-single-row.md
@@ -187,12 +187,23 @@ below. This is the runtime-data half of draft issue #20.
 ## Out of scope / backlog
 
 - **`file_metadata.authors` / `.commits`** (0/136k populated today) — keep the columns;
-  populate via a later sync/assessment pass for per-file complexity. Tracked:
-  deploy-kospex `planning/draft-issues.md` #23.
-- **Multi-branch** — once non-default branches are ingested, the `commit_files`
-  "last commit" lookup (`latest_commit_file_map`, `ORDER BY committer_when DESC`) needs
-  branch-awareness, and `latest`/`authors`/`commits` semantics need a branch dimension.
-  Separate design.
+  populate via a later sync/assessment pass for per-file complexity. Tracked as a
+  separate backlog item (to be filed against kospex).
+- **Multi-branch** — the intended end state is a clean split of scope:
+  **`file_metadata` = the default branch's current state** (one row per file as it
+  exists on the checked-out/default branch), while **`commits` / `commit_files` =
+  every branch** (`git log --all`) so developer-activity analytics see all work, not
+  just what merged to default. That split is a feature — but it means anything that
+  derives a `file_metadata` attribute *from* `commit_files` must be branch-aware:
+  - `latest_commit_file_map` must scope to the **default-branch ancestry** — otherwise
+    a file's "last changed" resolves to a feature-branch commit that isn't in the
+    snapshotted tree (see its docstring caveat).
+  - the `authors` / `commits` per-file columns inherit a decision: count across **all
+    branches** (richer developer map) or **default only** (matches the row's scope).
+  - `commit_files` will reference files **not** in `file_metadata` (branch-only files);
+    joins must tolerate that.
+  This needs a branch/ref dimension on `commit_files` and its own migration — a separate
+  design. `0003`'s `last_sync_hash` stays valid then (it means the default-branch HEAD).
 - **Incremental scanning** — panopticas + scc still scan the *whole* working tree each
   sync; the one-pass map only made the *commit lookup* cheap, not the *scan* itself.
   Row churn is already bounded to changed files (per-file hash) and the version-aware

--- a/src/kospex/db/migrations/0003_repos_sync_provenance.sql
+++ b/src/kospex/db/migrations/0003_repos_sync_provenance.sql
@@ -1,0 +1,20 @@
+-- 0003_repos_sync_provenance.sql
+--
+-- Provenance of the last successful file_metadata sync, per repo, so the
+-- skip-guard can decide whether a rebuild is needed without inspecting
+-- file_metadata rows. Rebuild when the repo HEAD moved OR panopticas/scc
+-- changed version since the values recorded here.
+--
+-- Existing rows get NULL ("unknown / never recorded"), which the guard treats
+-- as "must rebuild" — so the first sync after this migration always rebuilds.
+--
+-- Single-branch assumption: last_sync_hash is the HEAD of the checked-out
+-- (default) branch that file_metadata was snapshotted from. This holds while
+-- sync ingests only the default branch. When we move to syncing all branches
+-- (git log --all), file_metadata stays a default-branch snapshot, so this
+-- column still means "default-branch HEAD" — but per-branch provenance (if
+-- needed then) is a separate future migration.
+
+ALTER TABLE repos ADD COLUMN last_sync_hash TEXT;
+ALTER TABLE repos ADD COLUMN last_panopticas_version TEXT;
+ALTER TABLE repos ADD COLUMN last_scc_version TEXT;

--- a/src/kospex/db/migrator.py
+++ b/src/kospex/db/migrator.py
@@ -165,6 +165,12 @@ class Migrator:
         conn = self.db.conn
         sql = migration.sql_path.read_text()
         try:
+            # The shared sqlite_utils connection may already be mid-transaction
+            # (e.g. schema bootstrap on a fresh DB). Commit that first so our
+            # explicit BEGIN doesn't fail "cannot start a transaction within a
+            # transaction"; the migration then runs in its own transaction.
+            if conn.in_transaction:
+                conn.commit()
             conn.execute("BEGIN")
             # Split on `;` and execute each non-empty statement so DDL stays in tx
             for stmt in [s.strip() for s in sql.split(";") if s.strip()]:

--- a/src/kospex/extractors/pnpm.py
+++ b/src/kospex/extractors/pnpm.py
@@ -2,8 +2,7 @@
 
 Returns one record per resolved package (the full dependency closure),
 shaped to KospexDependencies.get_package_template() so ``krunner osi``
-consumes the records unchanged. Design:
-deploy-kospex/planning/pnpm-extractor-osi-plan.md.
+consumes the records unchanged.
 
 pnpm publishes a per-lockfileVersion spec at github.com/pnpm/spec
 (lockfile/{5,5.2,6.0,9.0}.md). Three structurally distinct families:

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -17,7 +17,6 @@ import panopticas
 from prettytable import PrettyTable, from_db_cursor
 from rich.console import Console as RichConsole
 from rich.table import Table as RichTable
-from sqlite_utils import Database
 
 import kospex_schema as KospexSchema
 import kospex_utils as KospexUtils
@@ -991,22 +990,11 @@ class Kospex:
                     "Bytes",
                 ]
 
-                commit_info_sql = f"""SELECT committer_when, hash FROM {KospexSchema.TBL_COMMIT_FILES}
-                WHERE file_path = ? and _repo_id = ? ORDER BY committer_when DESC LIMIT 1"""
-
-                #
-                # Create an in memory database to handle the queries, WAY FASTER
-                #
-
-                file_commits = self.kospex_query.get_commit_files(repo_id=repo_id)
-                # Create in-memory DB
-                db = Database(memory=True)  # equivalent to Database(":memory:")
-
-                # Insert: sqlite-utils will create the table and infer types automatically
-                # - pk sets primary key (optional)
-                # - alter=True allows adding new columns if later rows introduce them
-                table = db[KospexSchema.TBL_COMMIT_FILES]
-                table.insert_all(file_commits, alter=True)
+                # Each file's last commit (hash + date), built in a single pass
+                # over commit_files instead of a query per file against an
+                # in-memory copy (which was an unindexed scan per file — tens of
+                # seconds on large repos).
+                latest_commit = self.kospex_query.latest_commit_file_map(repo_id)
 
                 for row in csv_reader:
                     row = {key: row[key] for key in meta_cols if key in row}
@@ -1021,10 +1009,7 @@ class Kospex:
                     file_path = row.get("Provider")
                     if files.get(file_path):
                         print(f"file_path/Provider : {file_path}")
-                        # commit_info = next(self.kospex_db.query(commit_info_sql, [row['Provider'], repo_id]),None)
-                        commit_info = next(
-                            db.query(commit_info_sql, [row["Provider"], repo_id]), None
-                        )
+                        commit_info = latest_commit.get(row["Provider"])
 
                         if commit_info:
                             row["committer_when"] = commit_info.get("committer_when")

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -26,6 +26,58 @@ from kospex_git import KospexGit, MissingGitDirectory
 from kospex_query import KospexData, KospexQuery
 
 _console = RichConsole()
+log = KospexUtils.get_kospex_logger("kospex")
+
+
+def needs_metadata_rebuild(recorded, current, force=False):
+    """Decide whether file_metadata must be rebuilt for a repo.
+
+    ``recorded`` is the provenance stored on the repos row at the last
+    successful sync (keys: hash, panopticas_version, scc_version; values may be
+    None if never recorded). ``current`` holds the same keys for the current
+    HEAD + installed tool versions. Returns ``(needs_rebuild, reason)`` — the
+    reason names old -> new for a tool-version change so the caller can log an
+    audit trail (the repos columns are point-in-time and keep no history).
+    """
+    if force:
+        return True, "force requested"
+    if not recorded.get("hash"):
+        return True, "no prior file_metadata sync recorded"
+    if recorded.get("hash") != current.get("hash"):
+        return True, f"HEAD changed ({recorded.get('hash')} -> {current.get('hash')})"
+    # Versions are compared as opaque strings, never parsed as semver — we only
+    # care whether the tag changed, not ordering. This handles any format
+    # (pre-release suffixes like "-alpha"/"rc1", build metadata, 0.0.0, etc.).
+    # The repos columns are TEXT, and the helpers return the full version string.
+    for tool in ("panopticas", "scc"):
+        key = f"{tool}_version"
+        old, new = recorded.get(key), current.get(key)
+        if old != new:
+            return True, f"{tool} version changed ({old} -> {new})"
+    return False, "up to date"
+
+
+def panopticas_version():
+    """Installed panopticas package version, or None if it can't be resolved."""
+    try:
+        return version("panopticas")
+    except Exception:
+        return None
+
+
+def scc_version():
+    """Installed scc version parsed from `scc --version`, or None if scc is absent."""
+    if not which("scc"):
+        return None
+    try:
+        out = subprocess.run(
+            ["scc", "--version"], stdout=subprocess.PIPE, text=True, check=False
+        ).stdout
+        # e.g. "scc version 3.7.0" -> "3.7.0"
+        parts = out.split()
+        return parts[-1] if parts else None
+    except Exception:
+        return None
 
 
 class GitRepo(click.ParamType):
@@ -926,16 +978,23 @@ class Kospex:
         git_hash = self.git.get_current_hash()
         repo_id = self.git.get_repo_id()
 
-        # Check to see if we have already got metadata for this repo and hash
-        sql = f"""SELECT hash, _repo_id FROM {KospexSchema.TBL_FILE_METADATA}
-        WHERE hash = ? and _repo_id = ?"""
-        row = self.kospex_db.execute(sql, [git_hash, repo_id]).fetchone()
+        # Version-aware skip-guard: rebuild file_metadata only when the HEAD
+        # moved or panopticas/scc changed version since the last successful sync
+        # (recorded on the repos row). See needs_metadata_rebuild().
+        current = {
+            "hash": git_hash,
+            "panopticas_version": panopticas_version(),
+            "scc_version": scc_version(),
+        }
+        recorded = self._recorded_sync_provenance(repo_id)
+        rebuild, reason = needs_metadata_rebuild(recorded, current, force=force)
 
         data_rows = []
 
-        if row and not force:
-            print(f"Already have metadata for {git_hash} and repo_id {str(repo_id)}")
+        if not rebuild:
+            print(f"file_metadata up to date for {repo_id} ({reason})")
         else:
+            log.info(f"file_metadata rebuild for {repo_id}: {reason}")
             # scc wont' analyse everything, so we need to do a file find for items not analysed
             # files = self.git.get_repo_files(skip_last_commit=skip_last_commit)
             start = time.perf_counter()
@@ -990,10 +1049,47 @@ class Kospex:
                 data_rows, pk=["Provider", "hash", "_repo_id"]
             )
 
+            # Record what this rebuild was based on, for the next sync's guard.
+            self._record_sync_provenance(repo_id, current)
+
             print(f"Wrote {len(data_rows)} file_metadata rows for repo_id {repo_id}")
 
         self.chdir_original()
         return data_rows
+
+    def _recorded_sync_provenance(self, repo_id):
+        """The file_metadata provenance stored on the repos row (last synced HEAD
+        + panopticas/scc versions). Returns a dict with None values if the row or
+        the columns (pre-0003 DB) are absent — which makes the guard rebuild."""
+        empty = {"hash": None, "panopticas_version": None, "scc_version": None}
+        try:
+            row = self.kospex_db.execute(
+                "SELECT last_sync_hash, last_panopticas_version, last_scc_version "
+                f"FROM {KospexSchema.TBL_REPOS} WHERE _repo_id = ?",
+                [repo_id],
+            ).fetchone()
+        except Exception:
+            return empty  # provenance columns not present (migration 0003 not applied)
+        if not row:
+            return empty
+        return {"hash": row[0], "panopticas_version": row[1], "scc_version": row[2]}
+
+    def _record_sync_provenance(self, repo_id, current):
+        """Stamp the repos row with what the just-completed rebuild was based on."""
+        try:
+            self.kospex_db.execute(
+                f"UPDATE {KospexSchema.TBL_REPOS} SET last_sync_hash = ?, "
+                "last_panopticas_version = ?, last_scc_version = ? WHERE _repo_id = ?",
+                [
+                    current.get("hash"),
+                    current.get("panopticas_version"),
+                    current.get("scc_version"),
+                    repo_id,
+                ],
+            )
+            self.kospex_db.conn.commit()
+        except Exception:
+            pass  # columns absent (pre-0003) -> nothing to stamp
 
     def sync_metadata(self, data_directory):
         """Find all git repos and sync the metadata to the kospex database"""

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -945,95 +945,52 @@ class Kospex:
             print(f"get_repo_files executed in {(end - start) * 1000:.2f}ms")
             # This will be a dict of file paths and their metadata
 
-            # Reset "latest" flags to false
-            reset_last_sql = f"""UPDATE {KospexSchema.TBL_FILE_METADATA} SET LATEST = 0
-            WHERE _repo_id = ?"""
-            self.kospex_db.execute(reset_last_sql, [repo_id])
+            # Each file's last commit (hash + date) in a single pass over
+            # commit_files — the source of each row's per-file hash + date.
+            latest_commit = self.kospex_query.latest_commit_file_map(repo_id)
 
-            # Get the list of files with metadata ready for an upsert
-            # The following rename the "Location" Field to "Provider"
-            git_rows = KospexSchema.metadata_rows_from_repo_files(files)
-            # Also adds the Latest = 1
-
-            self.kospex_db.table(KospexSchema.TBL_FILE_METADATA).upsert_all(
-                git_rows, pk=["Provider", "hash", "_repo_id"]
-            )
-
-            # Check we've got scc installed, add additional metadata if we can
-            installed = which("scc")
-            if not installed:
-                print("""WARNING: scc is not installed.
-                         Please install scc from https://github.com/boyter/scc""")
-            else:
-                # Let's grab the file metadata using 'scc'
+            # scc metrics (Lines/Code/Complexity/...) keyed by file path, for the
+            # files scc can analyse. panopticas (via get_repo_files) covers the
+            # rest, including its UNKNOWN default.
+            scc_metrics = {}
+            if which("scc"):
                 metadata = subprocess.run(
                     ["scc", "--by-file", "-f", "csv"],
                     stdout=subprocess.PIPE,
                     text=True,
                     check=False,
                 )
+                # scc columns: Language,Provider,Filename,Lines,Code,Comments,
+                # Blanks,Complexity,Bytes[,ULOC] — Provider is the file path.
+                scc_cols = ("Lines", "Code", "Comments", "Blanks", "Complexity", "Bytes")
+                for scc_row in csv.DictReader(metadata.stdout.splitlines()):
+                    provider = scc_row.get("Provider")
+                    if provider:
+                        scc_metrics[provider] = {
+                            c: scc_row[c] for c in scc_cols if c in scc_row
+                        }
+            else:
+                print("""WARNING: scc is not installed.
+                         Please install scc from https://github.com/boyter/scc""")
 
-                csv_reader = csv.DictReader(metadata.stdout.splitlines())
-                # TODO - revist parsing of scc output
-                # As of version 3.3.3, the output is:
-                # Language,Provider,Filename,Lines,Code,Comments,Blanks,Complexity,Bytes,ULOC
-                # A new ULOC parameter was added, which is not currently in our schema
-                meta_cols = [
-                    "Language",
-                    "Provider",
-                    "Filename",
-                    "Lines",
-                    "Code",
-                    "Comments",
-                    "Blanks",
-                    "Complexity",
-                    "Bytes",
-                ]
+            # One current-state row per file: panopticas (all files, incl UNKNOWN)
+            # + scc metrics (where known) + last commit, keyed by the per-file
+            # last-commit hash (falls back to HEAD only for uncommitted files).
+            data_rows = KospexSchema.build_file_metadata_rows(
+                files, latest_commit, scc_metrics=scc_metrics, git_hash=git_hash
+            )
 
-                # Each file's last commit (hash + date), built in a single pass
-                # over commit_files instead of a query per file against an
-                # in-memory copy (which was an unindexed scan per file — tens of
-                # seconds on large repos).
-                latest_commit = self.kospex_query.latest_commit_file_map(repo_id)
+            # Reset "latest" flags for the repo, then write the current rows.
+            # Files no longer present stay at latest=0 (soft-delete tombstones).
+            reset_last_sql = f"""UPDATE {KospexSchema.TBL_FILE_METADATA} SET LATEST = 0
+            WHERE _repo_id = ?"""
+            self.kospex_db.execute(reset_last_sql, [repo_id])
 
-                for row in csv_reader:
-                    row = {key: row[key] for key in meta_cols if key in row}
-                    row["hash"] = git_hash
+            self.kospex_db.table(KospexSchema.TBL_FILE_METADATA).upsert_all(
+                data_rows, pk=["Provider", "hash", "_repo_id"]
+            )
 
-                    # TODO - this doesn't work, a newly cloned repo will have mtime of when it was cloned
-                    # row['_mtime'] = os.path.getmtime(row['Filename'])
-                    # Set this entry to the latest. Required for tech landscape queries
-                    row["latest"] = 1
-
-                    # We only want to add files which are managed by Git
-                    file_path = row.get("Provider")
-                    if files.get(file_path):
-                        print(f"file_path/Provider : {file_path}")
-                        commit_info = latest_commit.get(row["Provider"])
-
-                        if commit_info:
-                            row["committer_when"] = commit_info.get("committer_when")
-                            row["hash"] = commit_info.get("hash")
-                        else:
-                            print(f"commit_info is None for file_path : {file_path}")
-
-                        data_rows.append(self.git.add_git_to_dict(row))
-
-                    else:
-                        print(f"file_path/Provider : {file_path}, not managed by Git")
-
-                self.kospex_db.table(KospexSchema.TBL_FILE_METADATA).upsert_all(
-                    data_rows, pk=["Provider", "hash", "_repo_id"]
-                )
-
-                print(
-                    "Added "
-                    + str(len(data_rows))
-                    + " rows to "
-                    + KospexSchema.TBL_FILE_METADATA
-                    + " for repo_id "
-                    + str(self.git.get_repo_id())
-                )
+            print(f"Wrote {len(data_rows)} file_metadata rows for repo_id {repo_id}")
 
         self.chdir_original()
         return data_rows

--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -559,6 +559,12 @@ class KospexGit:
         unmanaged = 0
 
         for entry in p_files:
+            # Never record git internals as repo files. panopticas excludes
+            # .git on most repos but not reliably (e.g. a freshly-init'd repo),
+            # so exclude it explicitly here.
+            if entry == ".git" or entry.startswith(".git/") or "/.git/" in entry:
+                continue
+
             data = {}
             self.add_git_to_dict(data)
             data["hash"] = self.current_hash

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -555,6 +555,15 @@ class KospexQuery:
         per-file `ORDER BY committer_when DESC LIMIT 1` lookup). Built with one
         windowed query over commit_files instead of a query (or git command)
         per file — O(commit_files) once, then O(1) lookups by the caller.
+
+        Single-branch assumption: this ranks a file's commits purely by
+        committer_when across everything in commit_files. Sync currently ingests
+        only the default branch, so that is correct. When we sync all branches
+        (git log --all), commit_files will hold commits from every branch and a
+        file's "latest" could resolve to a commit on a branch that is NOT in the
+        checked-out (default) tree that file_metadata snapshots — so this must
+        then be scoped to the default-branch ancestry. See
+        changes/202606-file-metadata-single-row.md.
         """
         sql = f"""
         SELECT file_path, hash, committer_when FROM (

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -545,6 +545,35 @@ class KospexQuery:
 
         return kd.execute()
 
+    def latest_commit_file_map(self, repo_id):
+        """
+        Return each file's last commit for a repo as a single-pass map:
+
+            {file_path: {"hash": <hash>, "committer_when": <date>}}
+
+        "Latest" = the row with the greatest committer_when (matching the prior
+        per-file `ORDER BY committer_when DESC LIMIT 1` lookup). Built with one
+        windowed query over commit_files instead of a query (or git command)
+        per file — O(commit_files) once, then O(1) lookups by the caller.
+        """
+        sql = f"""
+        SELECT file_path, hash, committer_when FROM (
+            SELECT file_path, hash, committer_when,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY file_path ORDER BY committer_when DESC
+                   ) AS rn
+            FROM {KospexSchema.TBL_COMMIT_FILES}
+            WHERE _repo_id = ?
+        ) WHERE rn = 1
+        """
+        result = {}
+        for row in self.kospex_db.query(sql, [repo_id]):
+            result[row["file_path"]] = {
+                "hash": row["hash"],
+                "committer_when": row["committer_when"],
+            }
+        return result
+
     def get_file_collaborators(self, repo_id, file_path):
         """
         Get the author committer states dependencies for the given repo_id and file_path.

--- a/src/kospex_schema.py
+++ b/src/kospex_schema.py
@@ -518,6 +518,60 @@ def db_tags_to_array(db_tags):
     tags = grouped.split('|')
     return tags
 
+def build_file_metadata_rows(files, commit_map, scc_metrics=None, git_hash=None):
+    """
+    Build exactly one current-state file_metadata row per file, merging the
+    three sources that previously produced two divergent rows per file:
+
+      - panopticas walk (``files``): dict keyed by path, each value carrying
+        Location/Provider, Language, tech_type (list), Filename and the _git_*
+        fields (get_repo_files already ran add_git_to_dict).
+      - per-file last commit (``commit_map``): ``{path: {"hash", "committer_when"}}``
+        from KospexQuery.latest_commit_file_map().
+      - ``scc_metrics`` (optional): ``{path: {Lines, Code, Comments, Blanks,
+        Complexity, Bytes}}`` for the files scc could analyse.
+
+    ``hash`` is the file's own last-commit hash (so an unchanged file keeps a
+    stable primary key across syncs); it falls back to ``git_hash`` (repo HEAD)
+    only when a file has no commit entry (e.g. uncommitted). ``latest=1`` on
+    every row. Returns rows ready for upsert_all(pk=[Provider, hash, _repo_id]).
+    """
+    scc_metrics = scc_metrics or {}
+    git_fields = ("_git_server", "_git_owner", "_git_repo", "_repo_id")
+    scc_cols = ("Lines", "Code", "Comments", "Blanks", "Complexity", "Bytes")
+
+    rows = []
+    for meta in files.values():
+        provider = meta.get("Provider", meta.get("Location"))
+        row = {
+            "Provider": provider,
+            "Filename": meta.get("Filename"),
+            "Language": meta.get("Language"),
+            "tech_type": array_to_db_tags(meta.get("tech_type")),
+            "latest": 1,
+        }
+        for gk in git_fields:
+            if gk in meta:
+                row[gk] = meta[gk]
+
+        commit = commit_map.get(provider)
+        if commit:
+            row["hash"] = commit.get("hash")
+            row["committer_when"] = commit.get("committer_when")
+        else:
+            row["hash"] = git_hash
+
+        metrics = scc_metrics.get(provider)
+        if metrics:
+            for col in scc_cols:
+                if col in metrics:
+                    row[col] = metrics[col]
+
+        rows.append(row)
+
+    return rows
+
+
 def metadata_rows_from_repo_files(files):
     """
     This function takes a dict (file_path) to dict (file details)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared test fixtures.
+
+Kospex resolves paths through the HabitatConfig singleton and, during
+construction, writes several KOSPEX_* vars straight to os.environ (not via
+monkeypatch). Both leak across tests: a test that constructs Kospex with a
+throwaway KOSPEX_HOME can leave the singleton and env pointing at a now-deleted
+tmpdir, breaking a later test's DB-path resolution.
+
+This autouse fixture isolates those globals for every test: it snapshots and
+restores the KOSPEX_* env vars and resets the singleton before and after each
+test, so tests can't pollute one another regardless of run order.
+"""
+import os
+
+import pytest
+
+_KOSPEX_ENV_KEYS = (
+    "KOSPEX_HOME", "KOSPEX_DB", "KOSPEX_CONFIG", "KOSPEX_CODE", "KOSPEX_LOGS",
+    "KOSPEX_DUCKDB", "KOSPEX_STAGING", "KOSPEX_KRUNNER", "KOSPEX_ASSESSMENTS",
+)
+
+
+def _reset_habitat_singleton():
+    try:
+        from kospex.habitat_config import HabitatConfig
+        HabitatConfig.reset_instance()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kospex_globals():
+    saved = {k: os.environ.get(k) for k in _KOSPEX_ENV_KEYS}
+    _reset_habitat_singleton()
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    _reset_habitat_singleton()

--- a/tests/test_build_file_metadata_rows.py
+++ b/tests/test_build_file_metadata_rows.py
@@ -1,0 +1,84 @@
+"""Tests for KospexSchema.build_file_metadata_rows().
+
+The single-row builder merges the three sources that previously produced two
+separate rows per file into exactly one current-state row per file:
+
+  - panopticas walk  -> Provider, Language, tech_type (all files, incl UNKNOWN)
+  - per-file commit  -> hash (the file's last-commit hash) + committer_when
+  - scc              -> Lines/Code/Comments/Blanks/Complexity/Bytes (where scc knows it)
+
+hash is the file's last-commit hash, falling back to the repo HEAD only when a
+file has no commit entry. latest=1 on every row.
+"""
+import kospex_schema as KospexSchema
+
+
+def _panopticas_walk():
+    # Mirrors get_repo_files(): keyed by path, values carry Location, Language,
+    # tech_type (list), Filename, and _git_* (add_git_to_dict already ran).
+    git = {
+        "_git_server": "github.com", "_git_owner": "kospex",
+        "_git_repo": "kospex", "_repo_id": "github.com~kospex~kospex",
+    }
+    return {
+        "src/app.py": {"Location": "src/app.py", "Filename": "app.py",
+                       "Language": "Python", "tech_type": ["Python"], **git},
+        "data.bin": {"Location": "data.bin", "Filename": "data.bin",
+                     "Language": "UNKNOWN", "tech_type": [], **git},   # panopticas-only
+        "new.py": {"Location": "new.py", "Filename": "new.py",
+                   "Language": "Python", "tech_type": ["Python"], **git},  # not committed yet
+    }
+
+
+def test_merges_panopticas_scc_and_commit_into_one_row_per_file():
+    files = _panopticas_walk()
+    commit_map = {
+        "src/app.py": {"hash": "aaa111", "committer_when": "2025-05-01T00:00:00+00:00"},
+        "data.bin": {"hash": "bbb222", "committer_when": "2024-01-01T00:00:00+00:00"},
+        # new.py deliberately absent (uncommitted)
+    }
+    scc_metrics = {
+        "src/app.py": {"Lines": 100, "Code": 80, "Comments": 10, "Blanks": 10,
+                       "Complexity": 5, "Bytes": 2048},
+        # data.bin unknown to scc; new.py unknown to scc
+    }
+
+    rows = KospexSchema.build_file_metadata_rows(
+        files, commit_map, scc_metrics=scc_metrics, git_hash="HEADHASH"
+    )
+
+    assert len(rows) == 3  # exactly one row per file
+    by = {r["Provider"]: r for r in rows}
+
+    # scc-known + committed: full merge
+    app = by["src/app.py"]
+    assert app["hash"] == "aaa111"                       # per-file last-commit hash
+    assert app["committer_when"] == "2025-05-01T00:00:00+00:00"
+    assert app["Language"] == "Python"
+    assert app["tech_type"] == "|Python|"
+    assert app["Lines"] == 100 and app["Code"] == 80
+    assert app["latest"] == 1
+    assert app["_git_owner"] == "kospex"
+
+    # panopticas-only (scc-unknown) but committed: tags + date, no scc metrics
+    dbin = by["data.bin"]
+    assert dbin["hash"] == "bbb222"
+    assert dbin["committer_when"] == "2024-01-01T00:00:00+00:00"
+    assert dbin["Language"] == "UNKNOWN"
+    assert "Lines" not in dbin
+
+    # uncommitted file: HEAD fallback hash, no committer_when
+    new = by["new.py"]
+    assert new["hash"] == "HEADHASH"
+    assert new.get("committer_when") is None
+    assert new["latest"] == 1
+
+
+def test_tech_type_none_when_no_tags():
+    files = {
+        "x": {"Location": "x", "Filename": "x", "Language": "UNKNOWN",
+              "tech_type": None, "_repo_id": "s~o~r"},
+    }
+    rows = KospexSchema.build_file_metadata_rows(files, {}, git_hash="H")
+    assert rows[0]["tech_type"] is None
+    assert rows[0]["hash"] == "H"

--- a/tests/test_db_migrator.py
+++ b/tests/test_db_migrator.py
@@ -204,6 +204,30 @@ def test_apply_records_in_schema_migrations(tmp_path):
     assert rows == [("0003_widgets", 3, 0)]
 
 
+def test_apply_succeeds_when_connection_already_in_transaction(tmp_path):
+    """The real CLI reaches apply() with the sqlite_utils connection already
+    mid-transaction (schema bootstrap on a fresh DB), which made apply()'s
+    explicit BEGIN raise 'cannot start a transaction within a transaction'."""
+    from kospex.db.migrator import Migrator, discover_migrations
+    db = _baseline_db(tmp_path)
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    _write(migrations_dir / "0003_widgets.sql", "CREATE TABLE widgets (id INTEGER);")
+
+    # Simulate the bootstrap leaving an open implicit transaction.
+    db.conn.execute("BEGIN")
+    db.conn.execute("CREATE TABLE bootstrap (id INTEGER)")
+    assert db.conn.in_transaction
+
+    migrator = Migrator(db, migrations_dir=migrations_dir)
+    migrator.apply(discover_migrations(migrations_dir)[0])  # must not raise
+
+    tables = {r[0] for r in db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    assert "widgets" in tables
+
+
 def test_apply_runs_python_up_after_sql(tmp_path):
     from kospex.db.migrator import Migrator, discover_migrations
     db = _baseline_db(tmp_path)

--- a/tests/test_extractors_workflows.py
+++ b/tests/test_extractors_workflows.py
@@ -1,7 +1,6 @@
 """Tests for kospex.extractors.workflows.
 
-Covers the edge cases listed in deploy-kospex/feature/find-actions/SPEC.md
-and planning/find-actions-migration-plan.md §5.
+Covers the edge cases for the find-actions workflow extractor.
 """
 
 from pathlib import Path

--- a/tests/test_file_metadata_sync.py
+++ b/tests/test_file_metadata_sync.py
@@ -1,0 +1,130 @@
+"""End-to-end sync tests for the single current-state row-per-file behaviour.
+
+Drives the real Kospex.sync_repo() against a throwaway git repo + a throwaway
+KOSPEX_HOME (no shared DB touched), exercising panopticas + scc + the commit
+lookup + the single-row builder together.
+"""
+import os
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test", "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test", "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kospex_env():
+    """Kospex()/KospexUtils init writes KOSPEX_CONFIG/KOSPEX_LOGS/etc. straight to
+    os.environ (not via monkeypatch). Snapshot and restore all KOSPEX_* vars, and
+    reset the HabitatConfig singleton, so this test doesn't leak into others."""
+    keys = ("KOSPEX_HOME", "KOSPEX_DB", "KOSPEX_CONFIG", "KOSPEX_CODE", "KOSPEX_LOGS")
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    from kospex.habitat_config import HabitatConfig
+    HabitatConfig.reset_instance()
+
+
+def _git(repo, *args, date=None):
+    env = {**os.environ, **_GIT_ENV}
+    if date:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, env=env,
+    )
+
+
+def _make_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "remote", "add", "origin", "https://github.com/test/repo.git")
+    (repo / "app.py").write_text("def hi():\n    return 1\n")
+    (repo / "README.md").write_text("# hello\n")
+    _git(repo, "add", "-A")
+    # Explicit, distinct commit dates: latest_commit_file_map orders by
+    # committer_when, so same-second commits would tie ambiguously.
+    _git(repo, "commit", "-q", "-m", "init", date="2025-01-01T00:00:00")
+    return repo
+
+
+def _kospex(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("KOSPEX_HOME", str(home))
+    monkeypatch.setenv("KOSPEX_CODE", str(tmp_path / "code"))
+    # Pin KOSPEX_DB explicitly: KospexUtils init writes it straight to os.environ
+    # (not via monkeypatch), so it would otherwise leak a prior test's path, and
+    # HabitatConfig.db_path reads KOSPEX_DB ahead of KOSPEX_HOME.
+    monkeypatch.setenv("KOSPEX_DB", str(home / "kospex.db"))
+    # get_kospex_db_path() resolves via the HabitatConfig singleton, which caches
+    # its config from first construction — reset it so each test gets its own DB.
+    from kospex.habitat_config import HabitatConfig
+    HabitatConfig.reset_instance()
+    from kospex_core import Kospex
+    return Kospex()
+
+
+def _latest(db):
+    return list(db.query(
+        "SELECT Provider, hash, committer_when, Lines, latest "
+        "FROM file_metadata WHERE latest = 1"
+    ))
+
+
+def test_sync_writes_exactly_one_row_per_file(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    k = _kospex(tmp_path, monkeypatch)
+
+    k.sync_repo(str(repo))
+
+    rows = _latest(k.kospex_db)
+    by = {r["Provider"] for r in rows}
+    assert by == {"app.py", "README.md"}
+    assert len(rows) == 2  # exactly one latest=1 row per file
+
+    # committer_when populated for ALL files (not just scc-known ones)
+    assert all(r["committer_when"] for r in rows)
+
+    # scc knows Python -> app.py carries metrics
+    app = next(r for r in rows if r["Provider"] == "app.py")
+    assert app["Lines"] is not None
+
+
+def test_resync_after_change_churns_only_the_changed_file(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    k = _kospex(tmp_path, monkeypatch)
+    k.sync_repo(str(repo))
+    before = {r["Provider"]: r["hash"] for r in _latest(k.kospex_db)}
+
+    # change one file and commit at a later date -> HEAD moves
+    (repo / "app.py").write_text("def hi():\n    return 2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "change app", date="2025-06-01T00:00:00")
+
+    k.sync_repo(str(repo))
+    after = {r["Provider"]: r["hash"] for r in _latest(k.kospex_db)}
+
+    # unchanged file keeps its hash (no churn); changed file gets a new hash
+    assert after["README.md"] == before["README.md"]
+    assert after["app.py"] != before["app.py"]
+
+    # still exactly one latest=1 row per file
+    counts = {
+        r["Provider"]: r["n"] for r in k.kospex_db.query(
+            "SELECT Provider, SUM(latest) AS n FROM file_metadata GROUP BY Provider"
+        )
+    }
+    assert counts == {"README.md": 1, "app.py": 1}

--- a/tests/test_file_metadata_sync.py
+++ b/tests/test_file_metadata_sync.py
@@ -98,9 +98,11 @@ def test_sync_writes_exactly_one_row_per_file(tmp_path, monkeypatch):
     # committer_when populated for ALL files (not just scc-known ones)
     assert all(r["committer_when"] for r in rows)
 
-    # scc knows Python -> app.py carries metrics
-    app = next(r for r in rows if r["Provider"] == "app.py")
-    assert app["Lines"] is not None
+    # scc metrics are only present when the optional scc binary is installed
+    # (absent on CI); panopticas + commit data above cover the rest.
+    if shutil.which("scc"):
+        app = next(r for r in rows if r["Provider"] == "app.py")
+        assert app["Lines"] is not None
 
 
 def test_resync_after_change_churns_only_the_changed_file(tmp_path, monkeypatch):

--- a/tests/test_file_metadata_sync.py
+++ b/tests/test_file_metadata_sync.py
@@ -128,3 +128,53 @@ def test_resync_after_change_churns_only_the_changed_file(tmp_path, monkeypatch)
         )
     }
     assert counts == {"README.md": 1, "app.py": 1}
+
+
+def _add_provenance_columns(db):
+    """Simulate a 0003-migrated DB (connect_or_create makes the baseline repos)."""
+    for col in ("last_sync_hash", "last_panopticas_version", "last_scc_version"):
+        db.execute(f"ALTER TABLE repos ADD COLUMN {col} TEXT")
+    db.conn.commit()
+
+
+def _app_langs(db):
+    return [r["Language"] for r in db.query(
+        "SELECT Language FROM file_metadata WHERE Provider='app.py' AND latest=1"
+    )]
+
+
+def test_resync_skips_when_nothing_changed(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    k = _kospex(tmp_path, monkeypatch)
+    _add_provenance_columns(k.kospex_db)
+    k.sync_repo(str(repo))
+
+    # Sentinel: a rebuild would overwrite Language back to "Python".
+    k.kospex_db.execute(
+        "UPDATE file_metadata SET Language='SENTINEL' WHERE Provider='app.py' AND latest=1"
+    )
+    k.kospex_db.conn.commit()
+
+    k.sync_repo(str(repo))  # no git change, same tool versions -> guard skips
+
+    assert _app_langs(k.kospex_db) == ["SENTINEL"]  # untouched
+
+
+def test_resync_rebuilds_on_panopticas_version_bump(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    k = _kospex(tmp_path, monkeypatch)
+    _add_provenance_columns(k.kospex_db)
+    k.sync_repo(str(repo))
+
+    k.kospex_db.execute(
+        "UPDATE file_metadata SET Language='SENTINEL' WHERE Provider='app.py' AND latest=1"
+    )
+    k.kospex_db.conn.commit()
+
+    # A panopticas upgrade forces a re-tag even though no commits landed.
+    import kospex_core
+    monkeypatch.setattr(kospex_core, "panopticas_version", lambda: "999.0.0")
+
+    k.sync_repo(str(repo))
+
+    assert "SENTINEL" not in _app_langs(k.kospex_db)  # rebuilt in place

--- a/tests/test_kospex_cli_upgrade_db.py
+++ b/tests/test_kospex_cli_upgrade_db.py
@@ -1,53 +1,52 @@
-"""Integration tests for the `kospex upgrade-db` CLI command."""
-import os
+"""Tests for the `kospex upgrade-db` CLI command and the shipped migrations."""
 from pathlib import Path
 
 from click.testing import CliRunner
 
 
 def _setup_kospex_home(monkeypatch, tmp_path: Path) -> Path:
-    """Point KOSPEX_HOME at an isolated tmpdir so the CLI uses a throwaway DB."""
+    """Point KOSPEX_HOME/KOSPEX_DB at an isolated tmpdir so the CLI uses a
+    throwaway DB (HabitatConfig singleton reset is handled by the autouse
+    fixture in conftest.py)."""
     home = tmp_path / "kospex_home"
     home.mkdir()
     monkeypatch.setenv("KOSPEX_HOME", str(home))
+    monkeypatch.setenv("KOSPEX_DB", str(home / "kospex.db"))
     return home
 
 
-def test_upgrade_db_status_no_migrations(monkeypatch, tmp_path, capsys):
-    """Status mode against a fresh DB with no migrations on disk."""
+def test_upgrade_db_status_is_dry_run(monkeypatch, tmp_path):
+    """Status mode prints the version + backup warning and exits cleanly."""
     _setup_kospex_home(monkeypatch, tmp_path)
 
     from kospex_cli import cli
-    runner = CliRunner()
-    result = runner.invoke(cli, ["upgrade-db"])
+    result = CliRunner().invoke(cli, ["upgrade-db"])
 
     assert result.exit_code == 0, result.output
     assert "Kospex CLI version" in result.output
     assert "WARNING: backup your database" in result.output
-    # Migrator should report no migrations on disk (the package ships an empty migrations dir)
-    assert "No migrations on disk" in result.output or "0 pending" in result.output.lower()
 
 
-def test_upgrade_db_apply_runs_pending(monkeypatch, tmp_path):
-    """-apply mode actually runs migrations and updates the version int."""
-    home = _setup_kospex_home(monkeypatch, tmp_path)
-
-    # Initialize the DB by importing kospex_schema (triggers connect_or_create_kospex_db
-    # when the Kospex object is constructed during CLI invocation).
-    from kospex_cli import cli
-    from kospex.db import Migrator
-    import kospex_utils as KospexUtils
+def test_shipped_0003_adds_repos_provenance_columns(tmp_path):
+    """The shipped 0003 migration applies via the real migrator and adds the
+    sync-provenance columns to repos. Driven directly (not through the CLI) so
+    it doesn't depend on global KOSPEX_HOME/DB path resolution."""
     import sqlite_utils
+    import kospex_schema as KospexSchema
+    from kospex.db.migrator import Migrator
 
-    runner = CliRunner()
-    # First call creates the DB structure
-    runner.invoke(cli, ["upgrade-db"])
+    db = sqlite_utils.Database(tmp_path / "kospex.db")
+    db.execute(KospexSchema.SQL_CREATE_REPOS)
+    db.execute(
+        "CREATE TABLE schema_migrations ("
+        "id TEXT PRIMARY KEY, sequence INTEGER NOT NULL, checksum TEXT NOT NULL, "
+        "applied_at TEXT NOT NULL, duration_ms INTEGER, has_python INTEGER NOT NULL)"
+    )
 
-    # Insert one fake migration into the shipped migrations dir would require touching
-    # package data. Instead, point Migrator at a tmp migrations dir via env var or
-    # similar would be ideal — but for now the simpler verification is that -apply
-    # against an empty migrations dir cleanly reports "Nothing to apply".
-    result = runner.invoke(cli, ["upgrade-db", "-apply"])
+    Migrator(db).apply_pending()  # default dir = the shipped migrations (incl 0003)
 
-    assert result.exit_code == 0, result.output
-    assert "Nothing to apply" in result.output or "Applied 0 migration" in result.output
+    cols = {r[1] for r in db.execute("PRAGMA table_info(repos)")}
+    assert {"last_sync_hash", "last_panopticas_version", "last_scc_version"} <= cols
+
+    # Re-applying is a clean no-op (already recorded in schema_migrations).
+    assert Migrator(db).apply_pending() == []

--- a/tests/test_latest_commit_file_map.py
+++ b/tests/test_latest_commit_file_map.py
@@ -1,0 +1,83 @@
+"""Tests for KospexQuery.latest_commit_file_map().
+
+file_metadata sync needs each file's last-commit hash + date. Rather than an
+expensive per-file query (or a git command per file), this builds the whole
+map for a repo in a single pass over commit_files:
+
+    {file_path: {"hash": <last commit hash>, "committer_when": <its date>}}
+
+"Latest" matches the prior per-file lookup semantics: the row with the
+lexicographically-greatest committer_when (ORDER BY committer_when DESC).
+"""
+import os
+
+import pytest
+import sqlite_utils
+
+import kospex_schema as KospexSchema
+from kospex_query import KospexQuery
+
+
+@pytest.fixture(autouse=True)
+def _preserve_kospex_env():
+    """Constructing KospexQuery sets KOSPEX_* env vars as a side effect;
+    restore them so we don't leak state into later tests."""
+    keys = ("KOSPEX_CODE", "KOSPEX_DB", "KOSPEX_CONFIG", "KOSPEX_HOME", "KOSPEX_LOGS")
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def _seed(rows):
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_COMMIT_FILES)
+    db[KospexSchema.TBL_COMMIT_FILES].insert_all(
+        rows, pk=["hash", "file_path", "_repo_id"]
+    )
+    return KospexQuery(kospex_db=db)
+
+
+def test_returns_latest_commit_per_file():
+    kq = _seed([
+        # README.md changed twice -> newer commit wins
+        {"_repo_id": "s~o~r", "file_path": "README.md", "hash": "old",
+         "committer_when": "2025-01-01T00:00:00+00:00"},
+        {"_repo_id": "s~o~r", "file_path": "README.md", "hash": "new",
+         "committer_when": "2025-06-01T00:00:00+00:00"},
+        # LICENSE changed once
+        {"_repo_id": "s~o~r", "file_path": "LICENSE", "hash": "lic",
+         "committer_when": "2024-03-01T00:00:00+00:00"},
+    ])
+
+    m = kq.latest_commit_file_map("s~o~r")
+
+    assert set(m) == {"README.md", "LICENSE"}
+    assert m["README.md"]["hash"] == "new"
+    assert m["README.md"]["committer_when"] == "2025-06-01T00:00:00+00:00"
+    assert m["LICENSE"]["hash"] == "lic"
+
+
+def test_scoped_to_repo_id():
+    kq = _seed([
+        {"_repo_id": "s~o~r1", "file_path": "a.py", "hash": "r1",
+         "committer_when": "2025-01-01T00:00:00+00:00"},
+        {"_repo_id": "s~o~r2", "file_path": "a.py", "hash": "r2",
+         "committer_when": "2025-01-01T00:00:00+00:00"},
+    ])
+
+    m = kq.latest_commit_file_map("s~o~r1")
+
+    assert list(m) == ["a.py"]
+    assert m["a.py"]["hash"] == "r1"
+
+
+def test_empty_repo_returns_empty_map():
+    kq = _seed([
+        {"_repo_id": "s~o~r", "file_path": "a.py", "hash": "h",
+         "committer_when": "2025-01-01T00:00:00+00:00"},
+    ])
+    assert kq.latest_commit_file_map("s~o~nonexistent") == {}

--- a/tests/test_metadata_rebuild_guard.py
+++ b/tests/test_metadata_rebuild_guard.py
@@ -1,0 +1,65 @@
+"""Tests for the version-aware file_metadata rebuild guard.
+
+needs_metadata_rebuild() decides whether file_metadata must be rebuilt for a
+repo, given what was recorded at the last successful sync (repos provenance
+columns) vs the current HEAD + panopticas/scc versions. Rebuild when the HEAD
+moved OR a tool version changed OR nothing was recorded yet OR force.
+"""
+from kospex_core import needs_metadata_rebuild
+
+_CURRENT = {"hash": "h2", "panopticas_version": "0.0.16", "scc_version": "3.7.0"}
+
+
+def test_force_always_rebuilds():
+    recorded = dict(_CURRENT)
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT, force=True)
+    assert needed is True
+    assert "force" in reason.lower()
+
+
+def test_up_to_date_skips():
+    recorded = dict(_CURRENT)
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT)
+    assert needed is False
+
+
+def test_never_recorded_rebuilds():
+    recorded = {"hash": None, "panopticas_version": None, "scc_version": None}
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT)
+    assert needed is True
+
+
+def test_head_moved_rebuilds():
+    recorded = {**_CURRENT, "hash": "h1"}
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT)
+    assert needed is True
+    assert "hash" in reason.lower() or "head" in reason.lower()
+
+
+def test_panopticas_bump_rebuilds_and_names_versions():
+    recorded = {**_CURRENT, "panopticas_version": "0.0.15"}
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT)
+    assert needed is True
+    assert "panopticas" in reason.lower()
+    assert "0.0.15" in reason and "0.0.16" in reason  # old -> new for the audit log
+
+
+def test_scc_bump_rebuilds():
+    recorded = {**_CURRENT, "scc_version": "3.6.0"}
+    needed, reason = needs_metadata_rebuild(recorded, _CURRENT)
+    assert needed is True
+    assert "scc" in reason.lower()
+
+
+def test_versions_compared_as_opaque_strings():
+    # Pre-release / suffixed / non-numeric versions are handled by string
+    # equality — no semver parsing. A change to/from a suffix rebuilds...
+    cur = {"hash": "h", "panopticas_version": "0.0.16-alpha", "scc_version": "3.7.0"}
+    rec = {"hash": "h", "panopticas_version": "0.0.16", "scc_version": "3.7.0"}
+    needed, reason = needs_metadata_rebuild(rec, cur)
+    assert needed is True
+    assert "0.0.16-alpha" in reason
+
+    # ...and identical suffixed strings are treated as unchanged.
+    needed2, _ = needs_metadata_rebuild(dict(cur), cur)
+    assert needed2 is False


### PR DESCRIPTION
## Why

Started from a report that the `/osi/` page was stale. Investigation showed `/osi/`'s "days ago" was unreliable and, underneath, `file_metadata` was badly polluted: **94 of 95 repos had many commit hashes flagged `latest=1`** (apache/arrow: 1609, babel: 1540). Root cause: `file_metadata()` wrote **every file twice** under two different `hash` values — a panopticas row keyed by repo HEAD (carrying `tech_type`) and an scc row keyed by the file's own last-commit hash (carrying metrics + `committer_when`) — so the two halves never merged and both stayed `latest=1`.

Full design + investigation: `changes/202606-file-metadata-single-row.md`.

## What changed

- **One current-state row per file.** `build_file_metadata_rows()` merges panopticas (all files, incl. its UNKNOWN default) + scc metrics (where known) + each file's last commit into a single row keyed by the **per-file last-commit hash**; `file_metadata()` does one `reset latest=0` + merged upsert. `committer_when` is now populated for every committed file (this is what fixes `/osi/` "days ago").
- **One-pass commit lookup.** Replaced a load-all-`commit_files`-into-memory + unindexed scan-per-file lookup with a single windowed query (`latest_commit_file_map`). ~34s → ~1.4s on babel; identical output.
- **Version-aware skip-guard** (migration `0003`: `repos.last_sync_hash` / `last_panopticas_version` / `last_scc_version`). Rebuilds only when HEAD moved or panopticas/scc changed version; otherwise skips the whole scan. Versions compared as opaque strings (no semver parsing). Columns are point-in-time, so version transitions are logged to disk for an audit trail.
- **Incidental fixes found along the way:** `get_repo_files()` now excludes `.git/` explicitly (panopticas misses it on freshly-init'd repos); a latent migrator bug (`BEGIN` while already mid-transaction) that would have broken *any* migration; and a shared test-isolation `conftest` for kospex globals.

## Design decisions

- **Canonical `hash` = per-file last-commit hash**, not repo HEAD — information-dense, keeps unchanged files' PKs stable across syncs (only changed files churn), and is more multi-branch-resistant. HEAD is redundant (a single repo fact).
- **`file_metadata` = current-state snapshot**; history/churn stays in `commit_files` / `/hotspots/`. Single-branch today; when all-branch sync lands, `file_metadata` stays a default-branch snapshot and the commit lookup must scope to default-branch ancestry (documented, with a caveat in the code).

## Verification

- Full test suite green (274 passed); unit + end-to-end sync tests (one-row-per-file, 3-file churn invariant, guard skip/rebuild).
- Real-DB cleanup: `file_metadata` **144,645 → 74,016 rows**, all `latest=1`; **0** repos with a duplicate `latest=1` row; provenance stamped on 104/104 repos; `/osi/` dep rows now carry `tech_type` + `committer_when` together.

## Note for reviewers / merge

- Prefer **"Create a merge commit"** — the 9 commits are individually meaningful and tell the story in stages.
- `0003` must be applied (`kospex upgrade-db -apply`) after merge; it degrades to always-rebuild on a pre-`0003` DB.
- Deferred follow-up: the ~0.4% of rows for files with no commit-map entry (rename/path mismatch) fall back to a HEAD hash with no date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)