### PR TITLE
Fix /dependencies/ 500 on non-numeric versions_behind

### DIFF
--- a/src/templates/dependencies.html
+++ b/src/templates/dependencies.html
@@ -87,7 +87,7 @@
                                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ row['package_name'] }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right font-mono">{{ row['package_version'] }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right">
-                                        {% if row['versions_behind'] and row['versions_behind'] > 0 %}
+                                        {% if row['versions_behind'] is number and row['versions_behind'] > 0 %}
                                             <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-orange-100 text-orange-800">
                                                 {{ row['versions_behind'] }}
                                             </span>

--- a/tests/test_dependencies_template.py
+++ b/tests/test_dependencies_template.py
@@ -1,0 +1,36 @@
+"""Regression test for the /dependencies/ page rendering.
+
+`versions_behind` can be a non-numeric value ("Unknown" from krunner osi when
+deps.dev can't resolve a package@version, or "" from sca), and the template
+compared it with `> 0`, which raised TypeError on the truthy "Unknown" string
+and 500'd the page. The template must tolerate non-numeric values.
+"""
+import kweb2
+
+
+def _render(rows):
+    tmpl = kweb2.templates.get_template("dependencies.html")
+    return tmpl.render({"data": rows, "request": None})
+
+
+def test_dependencies_renders_with_non_numeric_versions_behind():
+    rows = [
+        {"package_name": "a", "package_version": "3.0", "package_type": "pypi",
+         "versions_behind": 3},          # numeric, behind -> shows the count
+        {"package_name": "b", "package_version": "^1.0", "package_type": "npm",
+         "versions_behind": "Unknown"},  # truthy string -> used to crash
+        {"package_name": "c", "package_version": "1.0", "package_type": "pypi",
+         "versions_behind": ""},         # empty string (sca)
+        {"package_name": "d", "package_version": "1.0", "package_type": "pypi",
+         "versions_behind": None},       # null
+        {"package_name": "e", "package_version": "1.0", "package_type": "pypi",
+         "versions_behind": 0},          # up to date
+    ]
+
+    html = _render(rows)  # must not raise
+
+    assert "3" in html            # the numeric-behind count is shown
+    assert "Up to date" in html   # non-numeric / 0 rows fall to the up-to-date branch
+    # every row rendered
+    for name in ("a", "b", "c", "d", "e"):
+        assert name in html


### PR DESCRIPTION
## Problem

The `/dependencies/` page returns **500**. `dependencies.html:90` did:
```jinja
{% if row['versions_behind'] and row['versions_behind'] > 0 %}
```
`versions_behind` is `"Unknown"` (a truthy string) for packages `krunner osi` couldn't resolve on deps.dev — i.e. the exact `package@version` lookup came back empty: an unresolved version spec (`^4.4.0`, `workspace:*`, git URL), a yanked version, a non-existent/typo/private package, or a transient API error. `'Unknown' > 0` raises `TypeError`, the handler catches it and returns 500. (sca's `""` empty strings are falsy and short-circuit safely; ints are fine — it's the 6 `"Unknown"` rows that trip it.)

## Fix

Guard the comparison with Jinja's `is number` test so non-numeric values fall to the existing "Up to date" branch instead of crashing:
```jinja
{% if row['versions_behind'] is number and row['versions_behind'] > 0 %}
```

Minimal fix to stop the 500. A follow-up will represent unresolved lookups properly — `versions_behind = NULL` plus a categorical `resolution` status (`unresolved_spec` / `package_not_found` / `version_yanked` / `no_version` / `lookup_error`) that's queryable and surfaced, so "couldn't resolve" stops masquerading as "Up to date".

## Testing

New `tests/test_dependencies_template.py` renders `dependencies.html` with numeric / `"Unknown"` / `""` / `None` / `0` rows — fails (TypeError) before the fix, passes after. Verified in-process that `GET /dependencies/` returns 200 (was 500). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)