### PR TITLE
feat: dependency resolution status — categorise & record why a deps.dev lookup failed

### DIFF
--- a/changes/202607-dependency-resolution-status-plan.md
+++ b/changes/202607-dependency-resolution-status-plan.md
@@ -1,0 +1,436 @@
+# Dependency Resolution Status — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Categorise *why* a deps.dev lookup failed (five categories + `resolved`) as a queryable `dependency_data.resolution` column + a disk log, normalise `versions_behind` to int-or-NULL, and show the category on `/dependencies/`.
+
+**Architecture:** Fold classification into the shared `depsdev_record` seam (krunner osi + pypi/npm assess all call it). A status-aware deps.dev fetch (new `url_request_with_status`) lets us split 404 from transient errors, and a cached package-level fallback splits `package_not_found` from `version_yanked`. A pre-call `is_concrete_version` check catches specs before hitting the API.
+
+**Tech Stack:** Python 3.12, sqlite_utils, requests, `packaging`, Click, Jinja2, pytest.
+
+**Spec:** `changes/202607-dependency-resolution-status.md`. **Depends on PR #105** (the `/dependencies/` template guard) — the badge task (Task 6) produces the final template regardless, but land #105 first and rebase to avoid a line-90 conflict. Run tests with `PYTHONPATH=$PWD/src python -m pytest ... -p no:cacheprovider` from the worktree.
+
+---
+
+## File structure
+
+- `src/kospex/db/migrations/0005_dependency_data_resolution.sql` — new: `resolution` column.
+- `src/kospex_query.py` — new `url_request_with_status()` (status-aware fetch).
+- `src/kospex_dependencies.py` — new `is_concrete_version()`, `deps_dev_status()`, `_classify_lookup_miss()`; classification folded into `depsdev_record()`.
+- `src/krunner.py` — osi loop reads `resolution`/`versions_behind` from the record.
+- `src/templates/dependencies.html` — resolution badge.
+- Tests: `tests/test_resolution_status.py` (classifier + helpers), extend `tests/test_db_migrator.py`, `tests/test_dependencies_template.py`.
+
+Reference decision tree (spec): empty→`no_version`; not concrete→`unresolved_spec`; deps.dev 200→`resolved`(+int); 404 & package exists→`version_yanked`; 404 & package missing→`package_not_found`; else→`lookup_error`.
+
+---
+
+## Task 1: Migration 0005 — `dependency_data.resolution`
+
+**Files:** Create `src/kospex/db/migrations/0005_dependency_data_resolution.sql`; Test: append to `tests/test_db_migrator.py`.
+
+- [ ] **Step 1: Failing test.** Append to `tests/test_db_migrator.py`:
+```python
+def test_shipped_0005_adds_dependency_data_resolution(tmp_path):
+    import sqlite_utils
+    import kospex_schema as KospexSchema
+    from kospex.db.migrator import Migrator
+    db = sqlite_utils.Database(tmp_path / "kospex.db")
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    db.execute(
+        "CREATE TABLE schema_migrations ("
+        "id TEXT PRIMARY KEY, sequence INTEGER NOT NULL, checksum TEXT NOT NULL, "
+        "applied_at TEXT NOT NULL, duration_ms INTEGER, has_python INTEGER NOT NULL)"
+    )
+    Migrator(db).apply_pending()
+    cols = {r[1] for r in db.execute("PRAGMA table_info(dependency_data)")}
+    assert "resolution" in cols
+```
+- [ ] **Step 2: Run, verify FAIL.** `PYTHONPATH=$PWD/src python -m pytest tests/test_db_migrator.py::test_shipped_0005_adds_dependency_data_resolution -v -p no:cacheprovider`
+- [ ] **Step 3: Create migration** `src/kospex/db/migrations/0005_dependency_data_resolution.sql`:
+```sql
+-- 0005_dependency_data_resolution.sql
+--
+-- Category for why a deps.dev version lookup resolved or failed: resolved,
+-- no_version, unresolved_spec, version_yanked, package_not_found, lookup_error.
+-- NULL means a legacy row not yet classified. Pairs with versions_behind, which
+-- is an integer when resolved and NULL otherwise.
+
+ALTER TABLE dependency_data ADD COLUMN resolution TEXT;
+```
+(Keep the comment free of `;` — the runner splits on `;`.)
+- [ ] **Step 4: Run, verify PASS.** Same command. Also `PYTHONPATH=$PWD/src python -m pytest tests/test_db_migrator.py -q -p no:cacheprovider`.
+- [ ] **Step 5: Commit.** `git add src/kospex/db/migrations/0005_dependency_data_resolution.sql tests/test_db_migrator.py && git commit -m "feat(db): 0005 add dependency_data.resolution"`
+
+---
+
+## Task 2: `KospexQuery.url_request_with_status`
+
+Status-aware fetch: returns `(content, status)`. Caches 200 bodies (like `url_request`); returns the HTTP status on failure so callers can categorise.
+
+**Files:** Modify `src/kospex_query.py` (add near `url_request`); Test: create `tests/test_resolution_status.py`.
+
+- [ ] **Step 1: Failing test.** Create `tests/test_resolution_status.py`:
+```python
+"""Tests for dependency resolution-status classification."""
+import sqlite_utils
+import kospex_schema as KospexSchema
+from kospex_query import KospexQuery
+
+
+def _kq():
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_URL_CACHE)
+    return KospexQuery(kospex_db=db)
+
+
+def test_url_request_with_status_200_returns_body_and_caches(monkeypatch):
+    kq = _kq()
+
+    class _Resp:
+        status_code = 200
+        text = '{"ok": true}'
+        def raise_for_status(self): pass
+
+    monkeypatch.setattr("kospex_query.requests.get", lambda *a, **k: _Resp())
+    content, status = kq.url_request_with_status("http://x/pkg")
+    assert status == 200 and content == '{"ok": true}'
+    # cached: a second call with requests.get patched to blow up still returns it
+    monkeypatch.setattr("kospex_query.requests.get",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should be cached")))
+    content2, status2 = kq.url_request_with_status("http://x/pkg")
+    assert status2 == 200 and content2 == '{"ok": true}'
+
+
+def test_url_request_with_status_404(monkeypatch):
+    import requests
+    kq = _kq()
+
+    class _Resp:
+        status_code = 404
+        text = "not found"
+        def raise_for_status(self):
+            raise requests.HTTPError(response=self)
+
+    monkeypatch.setattr("kospex_query.requests.get", lambda *a, **k: _Resp())
+    content, status = kq.url_request_with_status("http://x/missing")
+    assert content is None and status == 404
+
+
+def test_url_request_with_status_network_error(monkeypatch):
+    import requests
+    kq = _kq()
+    def _boom(*a, **k):
+        raise requests.ConnectionError("down")
+    monkeypatch.setattr("kospex_query.requests.get", _boom)
+    content, status = kq.url_request_with_status("http://x/err")
+    assert content is None and status is None
+```
+- [ ] **Step 2: Run, verify FAIL** (AttributeError, no `url_request_with_status`). `PYTHONPATH=$PWD/src python -m pytest tests/test_resolution_status.py -k url_request_with_status -v -p no:cacheprovider`. Confirm `requests` is imported in `kospex_query.py` (add `import requests` if missing) and `SQL_CREATE_URL_CACHE` exists in kospex_schema.
+- [ ] **Step 3: Implement.** Add to `src/kospex_query.py`:
+```python
+    def url_request_with_status(self, url, cache=3600, timeout=10, headers=None):
+        """Like url_request, but returns (content, status). status is 200 on a
+        cache hit or fresh success, the HTTP status on an HTTP error, or None on
+        a network/timeout error. 200 responses are cached; failures are not."""
+        cache_sql = f"SELECT content, timestamp FROM {KospexSchema.TBL_URL_CACHE} WHERE url = ?"
+        result = next(self.kospex_db.query(cache_sql, (url,)), None)
+        if result and (time.time() - result["timestamp"]) < cache:
+            return result["content"], 200
+        try:
+            response = requests.get(url, timeout=timeout, headers=headers)
+            response.raise_for_status()
+            content = response.text
+            self.kospex_db.table(KospexSchema.TBL_URL_CACHE).upsert(
+                {"url": url, "content": content, "timestamp": int(time.time())}, pk=["url"]
+            )
+            return content, 200
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            return None, status
+        except requests.RequestException:
+            return None, None
+```
+- [ ] **Step 4: Run, verify PASS.** Same `-k url_request_with_status` command.
+- [ ] **Step 5: Commit.** `git add src/kospex_query.py tests/test_resolution_status.py && git commit -m "feat(query): url_request_with_status for status-aware deps.dev fetch"`
+
+---
+
+## Task 3: `is_concrete_version`
+
+**Files:** Modify `src/kospex_dependencies.py`; Test: append to `tests/test_resolution_status.py`.
+
+- [ ] **Step 1: Failing test.** Append:
+```python
+import pytest
+from kospex_dependencies import KospexDependencies
+
+
+@pytest.mark.parametrize("v,expected", [
+    ("1.2.3", True), ("0.0.16", True), ("2.0.0rc1", True), ("1.2.3-beta.1", True),
+    ("", False), (None, False), ("^4.4.0", False), (">=1.0,<2.0", False),
+    ("~1.2", False), ("1.x", False), ("latest", False), ("*", False),
+    ("workspace:*", False), ("https://github.com/o/r", False), ("git+https://x", False),
+])
+def test_is_concrete_version(v, expected):
+    assert KospexDependencies().is_concrete_version(v) is expected
+```
+- [ ] **Step 2: Run, verify FAIL.** `PYTHONPATH=$PWD/src python -m pytest tests/test_resolution_status.py -k is_concrete_version -v -p no:cacheprovider`
+- [ ] **Step 3: Implement.** Add to `KospexDependencies` in `src/kospex_dependencies.py`:
+```python
+    # Markers that make a version string a range/spec/reference, not a concrete version.
+    _SPEC_MARKERS = ("^", "~", ">", "<", "=", "*", "|", " - ", "://", "workspace:",
+                     "file:", "link:", "git+", "portal:")
+
+    def is_concrete_version(self, version):
+        """True if `version` is a single concrete version (e.g. 1.2.3), not a
+        range/spec/URL/keyword. Used to skip deps.dev calls that would 404 on a
+        spec and to categorise them as unresolved_spec."""
+        if not version or not isinstance(version, str):
+            return False
+        v = version.strip()
+        if not v or v.lower() in ("latest", "next", "*", "x"):
+            return False
+        if any(m in v for m in self._SPEC_MARKERS):
+            return False
+        from packaging.version import Version, InvalidVersion
+        try:
+            Version(v)
+            return True
+        except InvalidVersion:
+            # Accept npm-ish concrete versions packaging can't parse (e.g. 1.2.3-beta.1)
+            return bool(re.match(r"^\d+(\.\d+){0,3}([-+][0-9A-Za-z.-]+)?$", v))
+```
+Confirm `import re` is present at the top of `kospex_dependencies.py` (it is; verify).
+- [ ] **Step 4: Run, verify PASS.** Same `-k is_concrete_version` command (all params pass).
+- [ ] **Step 5: Commit.** `git add src/kospex_dependencies.py tests/test_resolution_status.py && git commit -m "feat(deps): is_concrete_version helper"`
+
+---
+
+## Task 4: `deps_dev_status` + classification in `depsdev_record`
+
+The core. `deps_dev_status` does the status-aware exact-version lookup; the classification lives in `depsdev_record` so both krunner osi and assess get it.
+
+**Files:** Modify `src/kospex_dependencies.py`; Test: append to `tests/test_resolution_status.py`.
+
+- [ ] **Step 1: Failing test.** Append:
+```python
+class _StubQuery:
+    """Stub KospexQuery: url_request_with_status returns queued (content, status)."""
+    def __init__(self, version_result, package_result=None):
+        self._version = version_result      # (content, status) for the exact version
+        self._package = package_result      # (content, status) for the package-level call
+    def url_request_with_status(self, url, **kw):
+        return self._package if "/versions/" not in url else self._version
+
+
+def _deps(version_result, package_result=None):
+    kd = KospexDependencies(kospex_query=_StubQuery(version_result, package_result))
+    return kd
+
+
+def test_depsdev_record_no_version():
+    rec = _deps((None, None)).depsdev_record("pypi", "foo", "")
+    assert rec["resolution"] == "no_version" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_unresolved_spec():
+    rec = _deps((None, None)).depsdev_record("npm", "chartjs", "^4.4.0")
+    assert rec["resolution"] == "unresolved_spec" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_package_not_found():
+    # exact version 404, package-level also 404
+    rec = _deps(version_result=(None, 404), package_result=(None, 404)).depsdev_record(
+        "pypi", "nope-typo", "1.0.0")
+    assert rec["resolution"] == "package_not_found" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_version_yanked():
+    # exact version 404, but package exists
+    rec = _deps(version_result=(None, 404), package_result=('{"versions": []}', 200)).depsdev_record(
+        "pypi", "realpkg", "9.9.9")
+    assert rec["resolution"] == "version_yanked" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_lookup_error():
+    rec = _deps(version_result=(None, None)).depsdev_record("pypi", "x", "1.0.0")
+    assert rec["resolution"] == "lookup_error" and rec["versions_behind"] is None
+```
+- [ ] **Step 2: Run, verify FAIL.** `PYTHONPATH=$PWD/src python -m pytest tests/test_resolution_status.py -k depsdev_record -v -p no:cacheprovider` (KeyError `resolution` / wrong values).
+- [ ] **Step 3: Implement.** In `src/kospex_dependencies.py`, add the two helpers and rework `depsdev_record`'s lookup + failure path. Add:
+```python
+    def deps_dev_status(self, package_type, package_name, version):
+        """Exact-version deps.dev lookup returning (data|None, status)."""
+        encoded = urllib.parse.quote(package_name, safe="")
+        url = (f"https://api.deps.dev/v3alpha/systems/{package_type}"
+               f"/packages/{encoded}/versions/{version}")
+        content, status = self.kospex_query.url_request_with_status(url)
+        data = json.loads(content) if content else None
+        return data, status
+
+    def _package_exists(self, package_type, package_name):
+        """True if the package (any version) is known to deps.dev."""
+        encoded = urllib.parse.quote(package_name, safe="")
+        url = f"https://api.deps.dev/v3alpha/systems/{package_type}/packages/{encoded}"
+        content, status = self.kospex_query.url_request_with_status(url)
+        return bool(content)
+
+    def _classify_lookup_miss(self, package_type, package_name, status):
+        """Category for a failed exact-version lookup given its HTTP status."""
+        if status == 404:
+            return "version_yanked" if self._package_exists(package_type, package_name) \
+                else "package_not_found"
+        return "lookup_error"
+```
+Then modify `depsdev_record` — replace the current `deps_info = self.deps_dev(...)` + early-return block with the classified version, and set `resolution`/`versions_behind` throughout:
+```python
+    def depsdev_record(self, package_type, package_name, package_version):
+        """Convert a deps.dev package info record into a dictionary with other
+        metadata, including a `resolution` category and int-or-None versions_behind."""
+        details = {"package_name": package_name, "package_version": package_version,
+                   "package_type": package_type, "versions_behind": None}
+        today = datetime.datetime.now(datetime.timezone.utc)
+
+        if not package_version:
+            details["resolution"] = "no_version"
+            return details
+        if not self.is_concrete_version(package_version):
+            details["resolution"] = "unresolved_spec"
+            return details
+
+        deps_info, status = self.deps_dev_status(package_type, package_name, package_version)
+        if not deps_info:
+            details["resolution"] = self._classify_lookup_miss(package_type, package_name, status)
+            return details
+
+        # resolved
+        details["resolution"] = "resolved"
+        pub_date = deps_info.get("publishedAt")
+        if pub_date:
+            details["days_ago"] = (today - dateutil.parser.isoparse(pub_date)).days
+        details["published_at"] = pub_date
+        details["default"] = deps_info.get("isDefault")
+        details["source_repo"] = KospexUtils.extract_git_url(self.get_source_repo_info(deps_info))
+        details["advisories"] = self.get_advisories_count(deps_info)
+        days_info = self.get_versions_behind(package_type, package_name, package_version)
+        details["versions_behind"] = days_info.get("versions_behind")
+        details["authors"] = None
+        if details["source_repo"]:
+            details["authors"] = self.get_repo_authors(details["source_repo"])
+        return details
+```
+Note: the old `deps_dev()` method stays (other callers may use it); `depsdev_record` now uses `deps_dev_status`. `get_versions_behind` still runs on the resolved path (it does its own package-level fetch to count — unchanged).
+- [ ] **Step 4: Run, verify PASS.** `PYTHONPATH=$PWD/src python -m pytest tests/test_resolution_status.py -p no:cacheprovider` (all classifier tests).
+- [ ] **Step 5: Commit.** `git add src/kospex_dependencies.py tests/test_resolution_status.py && git commit -m "feat(deps): classify version lookups in depsdev_record (resolution + int/None versions_behind)"`
+
+---
+
+## Task 5: Carry `resolution` to the DB (krunner osi + save)
+
+**Files:** Modify `src/krunner.py` (osi enrichment loop) and confirm `src/kospex_dependencies.py` `save_dependencies`/assess persist `resolution`; Test: extend `tests/test_dependencies_save.py`.
+
+- [ ] **Step 1: Read the osi enrichment loop** in `src/krunner.py` (the block that sets `d["versions_behind"] = deps_rec.get("versions_behind", "Unknown")` and `d["advisories"] = ...`). Replace the versions_behind default and add resolution:
+```python
+        d["versions_behind"] = deps_rec.get("versions_behind")   # int or None, no "Unknown"
+        d["advisories"] = deps_rec.get("advisories")
+        d["resolution"] = deps_rec.get("resolution")
+```
+(Leave `published_at`/`package_type`/`package_use` handling as-is.)
+- [ ] **Step 1b: Audit the assess() ecosystem paths.** `assess()` saves the records its per-ecosystem assessors build. Confirm each routes version enrichment through `depsdev_record` (which now sets `resolution` — Task 4), so `resolution` is present on the saved record:
+  - `npm_assess` → `get_npm_dependency_dict` → `depsdev_record` ✓ (already routes through it).
+  - pyproject/pip path → `pypi_assess2` → `depsdev_record` ✓.
+  - `gomod_assess`, `nuget_assess`, pnpm path — grep each for where it sets `versions_behind` / calls deps.dev. If it routes through `depsdev_record`, no change. If it sets `versions_behind = ""`/`"Unknown"` itself (e.g. via `get_package_template`) without `depsdev_record`, either point that enrichment at `depsdev_record`, or — if its path is materially different — leave it as-is and add a one-line note here that it's a follow-up (its rows keep `resolution` NULL and render via the legacy branch). Do NOT half-wire it.
+- [ ] **Step 2: Confirm the DB writer keeps `resolution`.** `save_dependencies` (`src/kospex_dependencies.py`) upserts the row dicts; `resolution` is a plain column added by 0005, so it flows through. Verify `_NON_SCHEMA_FIELDS` (the strip-list) does NOT include `resolution` (it must be persisted). Add a test — append to `tests/test_dependencies_save.py`:
+```python
+def test_save_dependencies_persists_resolution():
+    import sqlite_utils, kospex_schema as KospexSchema
+    from kospex_dependencies import KospexDependencies
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    db.execute("ALTER TABLE dependency_data ADD COLUMN resolution TEXT")
+    kd = KospexDependencies(kospex_db=db)
+    kd.save_dependencies([{
+        "_repo_id": "s~o~r", "hash": "h", "file_path": "req.txt", "package_type": "pypi",
+        "package_name": "foo", "package_version": "^1.0",
+        "versions_behind": None, "resolution": "unresolved_spec",
+    }], source="krunner osi")
+    row = next(db.query("SELECT resolution, versions_behind FROM dependency_data"))
+    assert row["resolution"] == "unresolved_spec" and row["versions_behind"] is None
+```
+- [ ] **Step 3: Run, verify PASS** (or fix if `resolution` is stripped). `PYTHONPATH=$PWD/src python -m pytest tests/test_dependencies_save.py -p no:cacheprovider -q`
+- [ ] **Step 4: Log failures.** In `src/kospex_dependencies.py`, at the end of `depsdev_record` before each failure `return`, log via the module/instance logger (add `log = KospexUtils.get_kospex_logger("kospex")` at module top if absent, or reuse an existing logger). Minimal: one INFO line per non-resolved outcome:
+```python
+        # (in each failure branch, before return)
+        log.info(f"deps.dev unresolved [{details['resolution']}] {package_type} "
+                 f"{package_name} {package_version!r}")
+```
+Verify no test asserts silence; run `tests/test_resolution_status.py` again — still green.
+- [ ] **Step 5: Commit.** `git add src/krunner.py src/kospex_dependencies.py tests/test_dependencies_save.py && git commit -m "feat(deps): persist + log resolution; drop 'Unknown' versions_behind"`
+
+---
+
+## Task 6: `/dependencies/` resolution badge
+
+**Files:** Modify `src/templates/dependencies.html` (the versions-behind cell); Test: extend `tests/test_dependencies_template.py`.
+
+- [ ] **Step 1: Failing test.** Append to `tests/test_dependencies_template.py`:
+```python
+def test_dependencies_shows_resolution_category():
+    rows = [
+        {"package_name": "a", "package_type": "pypi", "package_version": "1", "resolution": "resolved", "versions_behind": 3},
+        {"package_name": "b", "package_type": "npm", "package_version": "^1", "resolution": "unresolved_spec", "versions_behind": None},
+        {"package_name": "c", "package_type": "pypi", "package_version": "9", "resolution": "package_not_found", "versions_behind": None},
+        {"package_name": "d", "package_type": "pypi", "package_version": "0", "resolution": "resolved", "versions_behind": 0},
+    ]
+    html = _render(rows)   # helper already in this file
+    assert "3" in html and "Up to date" in html
+    assert "unresolved spec" in html.lower()
+    assert "not found" in html.lower()
+```
+- [ ] **Step 2: Run, verify FAIL.** `PYTHONPATH=$PWD/src python -m pytest tests/test_dependencies_template.py -k resolution_category -v -p no:cacheprovider`
+- [ ] **Step 3: Implement.** Replace the versions-behind cell block in `src/templates/dependencies.html` (the `{% if row['versions_behind'] ... %}` block, ~line 89-99) with a 3-way that prefers a failure `resolution`:
+```jinja
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-right">
+                                        {% set _res = row['resolution'] %}
+                                        {% set _labels = {'unresolved_spec': 'unresolved spec', 'version_yanked': 'yanked', 'package_not_found': 'not found', 'no_version': 'no version', 'lookup_error': 'lookup error'} %}
+                                        {% if _res in _labels %}
+                                            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">
+                                                {{ _labels[_res] }}
+                                            </span>
+                                        {% elif row['versions_behind'] is number and row['versions_behind'] > 0 %}
+                                            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-orange-100 text-orange-800">
+                                                {{ row['versions_behind'] }}
+                                            </span>
+                                        {% else %}
+                                            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
+                                                Up to date
+                                            </span>
+                                        {% endif %}
+                                    </td>
+```
+(This subsumes the PR #105 `is number` guard. Legacy rows — `resolution` NULL — fall to the numeric/`Up to date` branch, rendering as they do post-#105.)
+- [ ] **Step 4: Run, verify PASS.** The new test AND the #105 tests: `PYTHONPATH=$PWD/src python -m pytest tests/test_dependencies_template.py -p no:cacheprovider -q`
+- [ ] **Step 5: Commit.** `git add src/templates/dependencies.html tests/test_dependencies_template.py && git commit -m "feat(web): show dependency resolution category on /dependencies/"`
+
+---
+
+## Task 7: Docs + full suite
+
+**Files:** Modify `changes/202607-dependency-resolution-status.md` (mark implemented); run full suite.
+
+- [ ] **Step 1: Note completion** at the top of `changes/202607-dependency-resolution-status.md` (the `resolution` column + five categories + badge shipped; migration `0005`).
+- [ ] **Step 2: Full suite.** `PYTHONPATH=$PWD/src python -m pytest -q -p no:cacheprovider`. Expect green except the 2 pre-existing `/dependencies/` **live-server** web-endpoint tests (they need a running server; the in-process template is now correct). scc-gated tests still pass without scc.
+- [ ] **Step 3: Commit.** `git add changes/202607-dependency-resolution-status.md && git commit -m "docs: mark resolution-status implemented"`
+
+---
+
+## Manual verification (before PR)
+
+```bash
+PYTHONPATH=$PWD/src python -c "import sys; sys.argv=['kospex','upgrade-db','-apply']; import kospex_cli; kospex_cli.cli()"   # apply 0005
+# re-run osi for a repo to classify its deps, then check the split:
+PYTHONPATH=$PWD/src python -c "import sys; sys.argv=['krunner','osi','github.com~kospex~kospex']; import krunner; krunner.cli()"
+PYTHONPATH=$PWD/src python -c "import kospex_utils as KU, sqlite3; db=sqlite3.connect(KU.get_kospex_db_path()); print(db.execute(\"SELECT resolution, COUNT(*) FROM dependency_data WHERE latest=1 GROUP BY resolution\").fetchall())"
+```
+Confirm the `resolution` counts split sensibly and `/dependencies/` returns 200 with category badges.

--- a/changes/202607-dependency-resolution-status.md
+++ b/changes/202607-dependency-resolution-status.md
@@ -1,5 +1,7 @@
 # Dependency resolution status — categorise & record why a lookup failed
 
+**Status: Implemented** via migration `0005` on branch `feature/dependency-resolution-status`. The `resolution` column classifies every dependency lookup into one of six categories; `/dependencies/` displays category badges for unresolved rows.
+
 ## Overview
 
 When kospex enriches a dependency via deps.dev, the lookup can come back empty.

--- a/changes/202607-dependency-resolution-status.md
+++ b/changes/202607-dependency-resolution-status.md
@@ -1,0 +1,136 @@
+# Dependency resolution status — categorise & record why a lookup failed
+
+## Overview
+
+When kospex enriches a dependency via deps.dev, the lookup can come back empty.
+Today that is flattened to `versions_behind = "Unknown"` (from `krunner osi`) or
+`""` (from `sca`) — a single opaque bucket that also crashed the `/dependencies/`
+page (fixed minimally in PR #105 with a template guard). Worse, the *reason* is
+lost: an unparseable version spec, a yanked version, a non-existent package, and
+a transient API error each need a different follow-up, but they all read the same.
+
+This records **why** each unresolved lookup failed, as a queryable category on
+`dependency_data`, plus a disk log — so the reasons can be investigated instead of
+guessed.
+
+Builds on PR #105 (the `/dependencies/` template guard). Land #105 first; this
+extends that same template.
+
+## Scope
+
+- **In:** a `resolution` category per dependency row (five failure categories +
+  `resolved`), `versions_behind` normalised to int-or-NULL, a centralised classifier
+  used by both DB-writing paths (`krunner osi`, `assess()`/`sca`), a disk log of
+  failures, and a `/dependencies/` badge that shows the category instead of the
+  misleading "Up to date".
+- **Out:** a summary/filter investigation surface on the page; retry logic for
+  transient errors; any scoring/prioritisation of which unknowns matter.
+
+## Data model
+
+Migration `0005` adds `dependency_data.resolution TEXT` (nullable). `versions_behind`
+is written as an integer when resolved, `NULL` otherwise (no more `"Unknown"`/`""`).
+
+| `resolution` | meaning | `versions_behind` |
+|---|---|---|
+| `resolved` | deps.dev knew the exact version | integer (0 = up to date) |
+| `no_version` | the dependency had no version to look up | NULL |
+| `unresolved_spec` | version isn't a concrete version (range `^1.0`, git URL, `workspace:*`, `latest`, …) | NULL |
+| `version_yanked` | package exists on deps.dev but that version doesn't | NULL |
+| `package_not_found` | the package itself isn't on deps.dev (typo / private / removed) | NULL |
+| `lookup_error` | transient deps.dev failure (5xx / timeout / non-404 error) | NULL |
+| `NULL` | legacy row, not yet classified (until re-run) | as-was |
+
+## The classifier (core new unit)
+
+A single function in `src/kospex_dependencies.py`:
+
+```
+resolve_version_status(package_type, name, version) -> {"resolution": str, "versions_behind": int | None}
+```
+
+Decision tree (short-circuits top to bottom):
+
+1. `version` empty/None → `no_version`.
+2. `version` is not a concrete version (a spec/range/git/`workspace:`/`latest`) →
+   `unresolved_spec`. Uses a `is_concrete_version(version)` helper (the same
+   concrete-vs-spec distinction `clean_version_spec` / `extract_purl` needs).
+3. Look up the exact version on deps.dev, **capturing the HTTP status**:
+   - `200` → compute `versions_behind` via `get_versions_behind` → `resolved`.
+   - `404` → package-level lookup (`deps_dev_package`, cached in `TBL_URL_CACHE`):
+     package missing → `package_not_found`; package present → `version_yanked`.
+   - anything else (5xx / timeout / exception) → `lookup_error`.
+
+**Enabler:** `deps_dev` currently returns `data` (or `None`), swallowing the status.
+Give it a status-aware form (e.g. `deps_dev_status(...) -> (data, status_int)`, with the
+existing `deps_dev` kept as a thin wrapper returning just `data` so current callers are
+unaffected). The extra package-level call happens only on a 404 and is cached, so
+re-runs are cheap.
+
+## Wiring + logging
+
+- **Integrate at the deps.dev-enrichment seam, not per call site.** Both DB-writing
+  paths already route their version enrichment through `depsdev_record` /
+  `get_versions_behind` (`src/kospex_dependencies.py`). Fold the classifier in there so
+  `depsdev_record` returns `{resolution, versions_behind}` (resolution `resolved` +
+  int, or a failure category + NULL) instead of an ad-hoc dict that omits
+  `versions_behind`. Then:
+  - `krunner osi` (`src/krunner.py`) — replace `deps_rec.get("versions_behind",
+    "Unknown")` with the record's `resolution` + `versions_behind`.
+  - `assess()`/`sca` (`src/kospex_dependencies.py`) — each per-ecosystem assessor
+    (`pypi_assess*`, `npm_assess`, `gomod_assess`, `nuget_assess`, pnpm) must route its
+    version enrichment through the same classifier rather than setting
+    `versions_behind` to `""`/`"Unknown"` itself. Audit each assessor for where it
+    computes/defaults `versions_behind` and point it at the seam. (If an assessor's
+    path is materially different and can't adopt the seam cleanly in this pass, note it
+    and scope it to a follow-up rather than half-wiring it.)
+- Both paths write `resolution` alongside the int-or-NULL `versions_behind`.
+- Every non-`resolved` outcome is logged to disk via `KospexUtils.get_kospex_logger`
+  at INFO, one line: `repo_id` (where available), package_type, name, version, category.
+  This is the greppable audit trail (the "log it too" half).
+- `save_dependencies` / the upsert path must accept `resolution` (add it to the row
+  dict; it's a plain column).
+
+## `/dependencies/` badge
+
+Extend the PR #105 template (`src/templates/dependencies.html`, the versions-behind
+cell): if `row['resolution']` is one of the five failure categories → a small
+gray/amber badge with a short human label ("unresolved spec", "yanked", "not found",
+"no version", "lookup error"); elif `versions_behind is number and > 0` → the existing
+orange count; else "Up to date". Unresolved rows stop reading as up-to-date.
+
+## Migration & existing rows
+
+`0005` adds the column (all existing rows get `resolution = NULL`). No risky backfill —
+existing `"Unknown"`/`""` rows are reclassified on their next `krunner osi` / `sca`
+run, which overwrites `versions_behind` + sets `resolution`. (A `krunner osi -all` after
+deploy refreshes everything.) The template treats `NULL` resolution as "fall back to the
+numeric/`Up to date` logic", so legacy rows render exactly as they do post-#105 until
+re-run.
+
+## Testing
+
+- **Classifier units** (stub the deps.dev status/data): one test per branch —
+  `no_version`, `unresolved_spec`, `resolved` (with a count), `version_yanked`,
+  `package_not_found`, `lookup_error`. Plus `is_concrete_version` unit tests
+  (`1.2.3` concrete; `^1.0`, `>=1,<2`, `workspace:*`, git URL, `latest`, `` not).
+- **Template**: render `dependencies.html` with rows for each badge branch → correct
+  label shown, no crash (extends the #105 test).
+- **Migration**: shipped-`0005` adds `resolution` (mirror the `0003`/`0004` tests).
+- **Wiring**: the existing `krunner osi` DB-write / `save_dependencies` tests assert a
+  `resolution` value is stored.
+
+## Files anticipated
+
+- `src/kospex/db/migrations/0005_dependency_data_resolution.sql`
+- `src/kospex_dependencies.py` — `resolve_version_status`, `is_concrete_version`,
+  status-aware deps.dev lookup; `assess()` uses the classifier.
+- `src/krunner.py` — `osi` enrichment loop uses the classifier.
+- `src/templates/dependencies.html` — resolution badge.
+- Tests as above.
+
+## Boundary note
+
+This stops at *categorised, queryable, logged* data + a de-misleading badge — the
+plumbing. Deciding which unresolved dependencies matter most (ranking/scoring) is
+deliberately out of scope.

--- a/changes/202607-dependency-resolution-status.md
+++ b/changes/202607-dependency-resolution-status.md
@@ -110,6 +110,12 @@ deploy refreshes everything.) The template treats `NULL` resolution as "fall bac
 numeric/`Up to date` logic", so legacy rows render exactly as they do post-#105 until
 re-run.
 
+**Deploy ordering (required).** Both DB-writing paths now emit `resolution` on every row,
+so `kospex upgrade-db -apply` must be run to add the `0005` column before the upgraded code
+writes dependencies. On a DB still on the old schema, `krunner osi` / `assess(save=True)`
+will fail with `no such column: resolution` (sqlite_utils does not auto-add columns). A
+freshly created DB likewise needs `upgrade-db -apply` before its first dependency write.
+
 ## Testing
 
 - **Classifier units** (stub the deps.dev status/data): one test per branch —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "duckdb==1.4.3",
     "prettytable==3.17.0",
     "dateutils",
+    "packaging",
     "panopticas==0.0.16",
     "python-dotenv",
     "sqlite-utils",

--- a/src/kospex/db/migrations/0005_dependency_data_resolution.sql
+++ b/src/kospex/db/migrations/0005_dependency_data_resolution.sql
@@ -1,0 +1,8 @@
+-- 0005_dependency_data_resolution.sql
+--
+-- Category for why a deps.dev version lookup resolved or failed: resolved,
+-- no_version, unresolved_spec, version_yanked, package_not_found, lookup_error.
+-- NULL means a legacy row not yet classified. Pairs with versions_behind, which
+-- is an integer when resolved and NULL otherwise.
+
+ALTER TABLE dependency_data ADD COLUMN resolution TEXT;

--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -103,6 +103,26 @@ class KospexDependencies:
 
         return data
 
+    def deps_dev_status(self, package_type, package_name, version):
+        """Exact-version deps.dev lookup returning (data|None, status)."""
+        encoded = urllib.parse.quote(package_name, safe="")
+        url = (f"https://api.deps.dev/v3alpha/systems/{package_type}"
+               f"/packages/{encoded}/versions/{version}")
+        content, status = self.kospex_query.url_request_with_status(url)
+        data = json.loads(content) if content else None
+        return data, status
+
+    def _package_exists(self, package_type, package_name):
+        """True if the package (any version) is known to deps.dev."""
+        return bool(self.deps_dev_package(package_type, package_name))
+
+    def _classify_lookup_miss(self, package_type, package_name, status):
+        """Category for a failed exact-version lookup given its HTTP status."""
+        if status == 404:
+            return "version_yanked" if self._package_exists(package_type, package_name) \
+                else "package_not_found"
+        return "lookup_error"
+
     def deps_dev_package(self, package_type, package_name):
         """
         Query the deps.dev API for a package and get all version history
@@ -593,54 +613,41 @@ class KospexDependencies:
         return record
 
     def depsdev_record(self, package_type, package_name, package_version):
-        """Convert a deps.dev package info record into a dictionary with other metadata"""
-
-        details = {}
-        details["package_name"] = package_name
-        details["package_version"] = package_version
-        details["package_type"] = package_type
-
-        deps_info = None
-
+        """Convert a deps.dev package info record into a dictionary with other
+        metadata, including a `resolution` category and int-or-None versions_behind."""
+        details = {"package_name": package_name, "package_version": package_version,
+                   "package_type": package_type, "versions_behind": None}
         today = datetime.datetime.now(datetime.timezone.utc)
-        # TODO - Handle bad package names
-        # TODO - Handle 404 errors (most likely due to bad package name)
-        if package_version:
-            deps_info = self.deps_dev(package_type, package_name, package_version)
 
-        # If we don't get any info back, we'll just return an empty dictionary
-        if not deps_info:
-            # details['source_repo'] = "Unknown, maybe internal library"
+        if not package_version:
+            details["resolution"] = "no_version"
+            return details
+        if not self.is_concrete_version(package_version):
+            details["resolution"] = "unresolved_spec"
             return details
 
-        pub_date = None
-        if deps_info:
-            pub_date = deps_info.get("publishedAt")
+        deps_info, status = self.deps_dev_status(package_type, package_name, package_version)
+        if not deps_info:
+            details["resolution"] = self._classify_lookup_miss(package_type, package_name, status)
+            return details
 
+        # resolved
+        details["resolution"] = "resolved"
+        pub_date = deps_info.get("publishedAt")
         if pub_date:
-            pub_date = dateutil.parser.isoparse(deps_info.get("publishedAt"))
-            diff = today - pub_date
-            details["days_ago"] = diff.days
-
-        details["published_at"] = deps_info.get("publishedAt")
+            details["days_ago"] = (today - dateutil.parser.isoparse(pub_date)).days
+        details["published_at"] = pub_date
         details["default"] = deps_info.get("isDefault")
         # TODO - need to parse the source repo to create proper links for NPM .. looks
         # a little dirty with actual Git urls and not https to Github
         details["source_repo"] = KospexUtils.extract_git_url(self.get_source_repo_info(deps_info))
         details["advisories"] = self.get_advisories_count(deps_info)
-
-        # Get the versions behind info
-        if package_version:
-            days_info = self.get_versions_behind(package_type, package_name, package_version)
-            details["versions_behind"] = days_info.get("versions_behind", "Unknown")
-
-        # TODO - this is a hacky way of duplicating the keys needed
-        # details['package_name'] = package_name
-        # details['package_version'] = package_version
+        days_info = self.get_versions_behind(package_type, package_name, package_version)
+        versions_behind = days_info.get("versions_behind")
+        details["versions_behind"] = versions_behind if isinstance(versions_behind, int) else None
         details["authors"] = None
         if details["source_repo"]:
             details["authors"] = self.get_repo_authors(details["source_repo"])
-
         return details
 
     def npm_assess(self, filename, results_file=None, repo_info=None, dev_deps=None):

--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -19,6 +19,7 @@ from xml.etree import ElementTree as ET
 import dateutil.parser
 import requests
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import Version, InvalidVersion
 from prettytable import PrettyTable
 
 import kospex_schema as KospexSchema
@@ -31,6 +32,10 @@ log = KospexUtils.get_kospex_logger("kospex_dependencies")
 class KospexDependencies:
     """kospex database query functionality"""
 
+    # Markers that make a version string a range/spec/reference, not a concrete version.
+    _SPEC_MARKERS = ("^", "~", ">", "<", "=", "*", "|", " - ", "://", "workspace:",
+                     "file:", "link:", "git+", "portal:")
+
     def __init__(self, kospex_db=None, kospex_query=None):
         # Initialize the kospex environment
         self.kospex_db = kospex_db
@@ -39,6 +44,24 @@ class KospexDependencies:
         # self.kospex_db = Database(KospexUtils.get_kospex_db_path())
         # The following will be the results from the list of dependencies from the assess command
         self.dependencies = []
+
+    def is_concrete_version(self, version):
+        """True if `version` is a single concrete version (e.g. 1.2.3), not a
+        range/spec/URL/keyword. Used to skip deps.dev calls that would 404 on a
+        spec and to categorise them as unresolved_spec."""
+        if not version or not isinstance(version, str):
+            return False
+        v = version.strip()
+        if not v or v.lower() in ("latest", "next", "*", "x"):
+            return False
+        if any(m in v for m in self._SPEC_MARKERS):
+            return False
+        try:
+            Version(v)
+            return True
+        except InvalidVersion:
+            # Accept npm-ish concrete versions packaging can't parse (e.g. 1.2.3-beta.1)
+            return bool(re.match(r"^\d+(\.\d+){0,3}([-+][0-9A-Za-z.-]+)?$", v))
 
     def extract_purl(self, purl):
         # Extract the purl from the given URL

--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -621,14 +621,20 @@ class KospexDependencies:
 
         if not package_version:
             details["resolution"] = "no_version"
+            log.info(f"deps.dev unresolved [{details['resolution']}] {package_type} "
+                     f"{package_name} {package_version!r}")
             return details
         if not self.is_concrete_version(package_version):
             details["resolution"] = "unresolved_spec"
+            log.info(f"deps.dev unresolved [{details['resolution']}] {package_type} "
+                     f"{package_name} {package_version!r}")
             return details
 
         deps_info, status = self.deps_dev_status(package_type, package_name, package_version)
         if not deps_info:
             details["resolution"] = self._classify_lookup_miss(package_type, package_name, status)
+            log.info(f"deps.dev unresolved [{details['resolution']}] {package_type} "
+                     f"{package_name} {package_version!r}")
             return details
 
         # resolved

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -1174,8 +1174,12 @@ class KospexQuery:
 
         return results
 
-    def url_request(self, url, cache=3600, timeout=10, headers=None):
-        """Make a request to a URL, and use the cached version is less than [cache] seconds"""
+    def url_request_with_status(self, url, cache=3600, timeout=10, headers=None):
+        """Make a request to a URL, and use the cached version if less than [cache] seconds.
+
+        Returns a (content, status) tuple: status is 200 on a cache hit or fresh
+        success, the HTTP status on an HTTP error, or None on a network/timeout
+        error. 200 responses are cached; failures are not."""
         # Set default cache to 1 hour (60mins * 60secs)
 
         # Check the cache first
@@ -1185,22 +1189,31 @@ class KospexQuery:
 
         if result and (time.time() - result["timestamp"]) < cache:
             # Cache is valid
-            content = result["content"]
-        else:
-            # Fetch new content and update the cache
-            try:
-                response = requests.get(url, timeout=timeout)
-                response.raise_for_status()  # Raise an exception for HTTP errors
-                content = response.text
+            return result["content"], 200
 
-                # Insert or update the cache
-                url_cache = {"url": url, "content": content, "timestamp": int(time.time())}
-                self.kospex_db.table(KospexSchema.TBL_URL_CACHE).upsert(url_cache, pk=["url"])
+        # Fetch new content and update the cache
+        try:
+            response = requests.get(url, timeout=timeout, headers=headers)
+            response.raise_for_status()  # Raise an exception for HTTP errors
+            content = response.text
 
-            except requests.RequestException as e:
-                print(f"Error fetching URL content: {e}")
-                content = None
+            # Insert or update the cache
+            url_cache = {"url": url, "content": content, "timestamp": int(time.time())}
+            self.kospex_db.table(KospexSchema.TBL_URL_CACHE).upsert(url_cache, pk=["url"])
 
+            return content, 200
+
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else None
+            return None, status
+        except requests.RequestException:
+            return None, None
+
+    def url_request(self, url, cache=3600, timeout=10, headers=None):
+        """Make a request to a URL, and use the cached version is less than [cache] seconds"""
+        content, _status = self.url_request_with_status(
+            url, cache=cache, timeout=timeout, headers=headers
+        )
         return content
 
     def get_repo_ids(self):

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -684,8 +684,9 @@ def osi(all, request_id):
             kdeps.clean_version_spec(d["package_version"]),
         )
         console.print(deps_rec)
-        d["versions_behind"] = deps_rec.get("versions_behind", "Unknown")
-        d["advisories"] = deps_rec.get("advisories", "Unknown")
+        d["versions_behind"] = deps_rec.get("versions_behind")   # int or None, no "Unknown"
+        d["advisories"] = deps_rec.get("advisories")
+        d["resolution"] = deps_rec.get("resolution")
         published = deps_rec.get("published_at", None)
         if published:
             d["published_at"] = published.split("T")[0]

--- a/src/kweb2.py
+++ b/src/kweb2.py
@@ -1325,6 +1325,45 @@ async def commit(request: Request, repo_id: str, commit_hash: str):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+# Human-readable labels for the failure `resolution` categories a dependency
+# item can carry when deps.dev could not resolve it. Kept in sync with the
+# `_labels` map used on the /dependencies/ page (src/templates/dependencies.html).
+UNRESOLVED_STATUS_LABELS = {
+    "unresolved_spec": "Unresolved spec",
+    "version_yanked": "Yanked",
+    "package_not_found": "Not found",
+    "no_version": "No version",
+    "lookup_error": "Lookup error",
+}
+
+
+def _classify_upload_status(item: dict) -> str:
+    """Classify a single package-check result item into a status string.
+
+    Precedence: advisories (Vulnerable) wins over everything else - a package
+    that is both vulnerable and unresolved is most usefully flagged as
+    Vulnerable. Then an honest label for unresolved/failed-resolution items,
+    then the existing numeric versions_behind tiers. `versions_behind` and
+    `advisories` are coalesced to 0 so an explicit None (used for unresolved
+    dependencies) never reaches a numeric comparison.
+    """
+    advisories = item.get("advisories") or 0
+    versions_behind = item.get("versions_behind") or 0
+
+    if advisories > 0:
+        return "Vulnerable"
+
+    resolution = item.get("resolution")
+    if resolution in UNRESOLVED_STATUS_LABELS:
+        return UNRESOLVED_STATUS_LABELS[resolution]
+
+    if versions_behind > 6:
+        return "Outdated"
+    elif versions_behind > 2:
+        return "Behind"
+    return "Current"
+
+
 @app.get("/package-check/", response_class=HTMLResponse)
 async def package_check(request: Request):
     """Display the package check page with drag and drop interface"""
@@ -1372,16 +1411,9 @@ async def package_check_upload(file: UploadFile = File(...)):
             os.remove(temp_path)
             os.rmdir(temp_dir)
 
-            # Add status based on advisories and versions behind
+            # Add status based on advisories, resolution and versions behind
             for item in results:
-                if item.get("advisories", 0) > 0:
-                    item["status"] = "Vulnerable"
-                elif item.get("versions_behind", 0) > 6:
-                    item["status"] = "Outdated"
-                elif item.get("versions_behind", 0) > 2:
-                    item["status"] = "Behind"
-                else:
-                    item["status"] = "Current"
+                item["status"] = _classify_upload_status(item)
 
             return JSONResponse(content=results)
 

--- a/src/templates/dependencies.html
+++ b/src/templates/dependencies.html
@@ -87,7 +87,13 @@
                                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ row['package_name'] }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right font-mono">{{ row['package_version'] }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right">
-                                        {% if row['versions_behind'] is number and row['versions_behind'] > 0 %}
+                                        {% set _res = row['resolution'] %}
+                                        {% set _labels = {'unresolved_spec': 'unresolved spec', 'version_yanked': 'yanked', 'package_not_found': 'not found', 'no_version': 'no version', 'lookup_error': 'lookup error'} %}
+                                        {% if _res in _labels %}
+                                            <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">
+                                                {{ _labels[_res] }}
+                                            </span>
+                                        {% elif row['versions_behind'] is number and row['versions_behind'] > 0 %}
                                             <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-orange-100 text-orange-800">
                                                 {{ row['versions_behind'] }}
                                             </span>

--- a/tests/test_db_migrator.py
+++ b/tests/test_db_migrator.py
@@ -501,13 +501,31 @@ def test_shipped_0004_adds_repos_last_fetch(tmp_path):
 
     db = sqlite_utils.Database(tmp_path / "kospex.db")
     db.execute(KospexSchema.SQL_CREATE_REPOS)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
     db.execute(
         "CREATE TABLE schema_migrations ("
         "id TEXT PRIMARY KEY, sequence INTEGER NOT NULL, checksum TEXT NOT NULL, "
         "applied_at TEXT NOT NULL, duration_ms INTEGER, has_python INTEGER NOT NULL)"
     )
 
-    Migrator(db).apply_pending()  # default dir = shipped migrations (incl 0003, 0004)
+    Migrator(db).apply_pending()  # default dir = shipped migrations (incl 0003, 0004, 0005)
 
     cols = {r[1] for r in db.execute("PRAGMA table_info(repos)")}
     assert "last_fetch" in cols
+
+
+def test_shipped_0005_adds_dependency_data_resolution(tmp_path):
+    import sqlite_utils
+    import kospex_schema as KospexSchema
+    from kospex.db.migrator import Migrator
+    db = sqlite_utils.Database(tmp_path / "kospex.db")
+    db.execute(KospexSchema.SQL_CREATE_REPOS)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    db.execute(
+        "CREATE TABLE schema_migrations ("
+        "id TEXT PRIMARY KEY, sequence INTEGER NOT NULL, checksum TEXT NOT NULL, "
+        "applied_at TEXT NOT NULL, duration_ms INTEGER, has_python INTEGER NOT NULL)"
+    )
+    Migrator(db).apply_pending()
+    cols = {r[1] for r in db.execute("PRAGMA table_info(dependency_data)")}
+    assert "resolution" in cols

--- a/tests/test_dependencies_save.py
+++ b/tests/test_dependencies_save.py
@@ -116,3 +116,19 @@ def test_save_dependencies_empty_is_noop():
     kdeps = KospexDependencies(kospex_db=db)
     assert kdeps.save_dependencies([], source="krunner osi") == 0
     assert list(db[KospexSchema.TBL_DEPENDENCY_DATA].rows) == []
+
+
+def test_save_dependencies_persists_resolution():
+    import sqlite_utils, kospex_schema as KospexSchema
+    from kospex_dependencies import KospexDependencies
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    db.execute("ALTER TABLE dependency_data ADD COLUMN resolution TEXT")
+    kd = KospexDependencies(kospex_db=db)
+    kd.save_dependencies([{
+        "_repo_id": "s~o~r", "hash": "h", "file_path": "req.txt", "package_type": "pypi",
+        "package_name": "foo", "package_version": "^1.0",
+        "versions_behind": None, "resolution": "unresolved_spec",
+    }], source="krunner osi")
+    row = next(db.query("SELECT resolution, versions_behind FROM dependency_data"))
+    assert row["resolution"] == "unresolved_spec" and row["versions_behind"] is None

--- a/tests/test_dependencies_template.py
+++ b/tests/test_dependencies_template.py
@@ -34,3 +34,16 @@ def test_dependencies_renders_with_non_numeric_versions_behind():
     # every row rendered
     for name in ("a", "b", "c", "d", "e"):
         assert name in html
+
+
+def test_dependencies_shows_resolution_category():
+    rows = [
+        {"package_name": "a", "package_type": "pypi", "package_version": "1", "resolution": "resolved", "versions_behind": 3},
+        {"package_name": "b", "package_type": "npm", "package_version": "^1", "resolution": "unresolved_spec", "versions_behind": None},
+        {"package_name": "c", "package_type": "pypi", "package_version": "9", "resolution": "package_not_found", "versions_behind": None},
+        {"package_name": "d", "package_type": "pypi", "package_version": "0", "resolution": "resolved", "versions_behind": 0},
+    ]
+    html = _render(rows)   # helper already in this file
+    assert "3" in html and "Up to date" in html
+    assert "unresolved spec" in html.lower()
+    assert "not found" in html.lower()

--- a/tests/test_kospex_cli_upgrade_db.py
+++ b/tests/test_kospex_cli_upgrade_db.py
@@ -37,6 +37,7 @@ def test_shipped_0003_adds_repos_provenance_columns(tmp_path):
 
     db = sqlite_utils.Database(tmp_path / "kospex.db")
     db.execute(KospexSchema.SQL_CREATE_REPOS)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
     db.execute(
         "CREATE TABLE schema_migrations ("
         "id TEXT PRIMARY KEY, sequence INTEGER NOT NULL, checksum TEXT NOT NULL, "

--- a/tests/test_package_check_upload.py
+++ b/tests/test_package_check_upload.py
@@ -1,0 +1,139 @@
+"""Regression test for POST /package-check/upload.
+
+Since the resolution-status work, an unresolved dependency carries an
+explicit `versions_behind: None` (plus a `resolution` failure category)
+instead of simply omitting the `versions_behind` key. The status-classification
+loop in kweb2.package_check_upload used `item.get("versions_behind", 0)`,
+which only falls back to 0 when the key is *absent* - with the key present
+and set to None, `None > 6` raised TypeError, which the endpoint's blanket
+`except Exception` turned into an HTTP 500. Any uploaded manifest containing
+a single unresolved dependency (git/URL dep, `workspace:*`, `*`, `latest`,
+a typo'd/private package, or anything deps.dev can't resolve) 500'd the
+entire response.
+
+The fix coalesces versions_behind/advisories to 0 before comparing, and
+additionally surfaces an honest status label for unresolved items instead of
+letting them silently read as "Current". Both the pure classification logic
+and the full endpoint round-trip are exercised here.
+"""
+import kweb2
+from kweb2 import UNRESOLVED_STATUS_LABELS, _classify_upload_status
+
+
+# ---------------------------------------------------------------------------
+# Unit tests against the pure helper (no server, no DB)
+# ---------------------------------------------------------------------------
+
+def test_unresolved_item_gets_honest_label_not_current():
+    item = {
+        "package_name": "left-pad",
+        "package_version": "^1.0",
+        "package_type": "npm",
+        "versions_behind": None,
+        "resolution": "unresolved_spec",
+    }
+    status = _classify_upload_status(item)  # must not raise
+    assert status == UNRESOLVED_STATUS_LABELS["unresolved_spec"]
+    assert status != "Current"
+
+
+def test_all_failure_resolutions_produce_their_label_and_do_not_crash():
+    for resolution, label in UNRESOLVED_STATUS_LABELS.items():
+        item = {
+            "package_name": "x",
+            "package_version": "?",
+            "package_type": "npm",
+            "versions_behind": None,
+            "resolution": resolution,
+        }
+        assert _classify_upload_status(item) == label
+
+
+def test_advisories_win_over_unresolved_label():
+    item = {
+        "package_name": "vulnerable-and-unresolved",
+        "package_version": "?",
+        "package_type": "npm",
+        "versions_behind": None,
+        "resolution": "package_not_found",
+        "advisories": 2,
+    }
+    assert _classify_upload_status(item) == "Vulnerable"
+
+
+def test_resolved_behind_item_keeps_numeric_tier():
+    outdated = {"package_name": "a", "versions_behind": 10, "resolution": "resolved"}
+    behind = {"package_name": "b", "versions_behind": 3, "resolution": "resolved"}
+    current = {"package_name": "c", "versions_behind": 0, "resolution": "resolved"}
+    assert _classify_upload_status(outdated) == "Outdated"
+    assert _classify_upload_status(behind) == "Behind"
+    assert _classify_upload_status(current) == "Current"
+
+
+def test_legacy_row_without_resolution_key_is_unchanged():
+    # Pre-this-branch rows never had a `resolution` key at all.
+    legacy_outdated = {"package_name": "a", "versions_behind": 10}
+    legacy_current = {"package_name": "b", "versions_behind": 0}
+    assert _classify_upload_status(legacy_outdated) == "Outdated"
+    assert _classify_upload_status(legacy_current) == "Current"
+
+
+def test_legacy_row_missing_versions_behind_key_entirely():
+    # Belt-and-braces: the very old failure-path dict had no key at all.
+    assert _classify_upload_status({"package_name": "a"}) == "Current"
+
+
+# ---------------------------------------------------------------------------
+# Full endpoint round-trip via FastAPI TestClient (pattern already used in
+# tests/test_repo_org_header.py and tests/test_kweb_help.py)
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def client():
+    pytest.importorskip("httpx", reason="httpx required for FastAPI TestClient")
+    from fastapi.testclient import TestClient
+
+    return TestClient(kweb2.app)
+
+
+def test_upload_endpoint_does_not_500_on_unresolved_dependency(client, monkeypatch):
+    fake_results = [
+        {
+            "package_name": "some-git-dep",
+            "package_version": "workspace:*",
+            "package_type": "npm",
+            "versions_behind": None,
+            "resolution": "unresolved_spec",
+        },
+        {
+            "package_name": "requests",
+            "package_version": "2.0.0",
+            "package_type": "pypi",
+            "versions_behind": 1,
+            "resolution": "resolved",
+            "advisories": 0,
+        },
+    ]
+
+    def fake_assess(self, filename, **kwargs):
+        return fake_results
+
+    monkeypatch.setattr(
+        "kospex_dependencies.KospexDependencies.assess", fake_assess
+    )
+
+    resp = client.post(
+        "/package-check/upload",
+        files={"file": ("package.json", b'{"dependencies": {}}', "application/json")},
+    )
+
+    assert resp.status_code == 200  # pre-fix this was a 500 (TypeError: '>' not supported)
+    body = resp.json()
+    by_name = {row["package_name"]: row for row in body}
+
+    assert by_name["some-git-dep"]["status"] == "Unresolved spec"
+    assert by_name["some-git-dep"]["status"] != "Current"
+    assert by_name["requests"]["status"] == "Current"

--- a/tests/test_resolution_status.py
+++ b/tests/test_resolution_status.py
@@ -1,4 +1,5 @@
 """Tests for dependency resolution-status classification."""
+import json
 import sqlite_utils
 import kospex_schema as KospexSchema
 from kospex_query import KospexQuery
@@ -85,3 +86,81 @@ from kospex_dependencies import KospexDependencies
 ])
 def test_is_concrete_version(v, expected):
     assert KospexDependencies().is_concrete_version(v) is expected
+
+
+class _StubQuery:
+    """Stub KospexQuery: url_request_with_status returns queued (content, status)
+    for the exact-version lookup (deps_dev_status). url_request (bare content on
+    success, None otherwise) drives the package-level lookup used by both
+    deps_dev_package (KospexDependencies._package_exists) and get_versions_behind
+    (via get_url_json) -- both hit the same package-level URL (no "/versions/")."""
+    def __init__(self, version_result, package_result=None):
+        self._version = version_result      # (content, status) for the exact version
+        self._package = package_result      # (content, status) for the package-level call
+
+    def url_request_with_status(self, url, **kw):
+        return self._package if "/versions/" not in url else self._version
+
+    def url_request(self, url, **kw):
+        if self._package is None:
+            return None
+        content, status = self._package
+        return content if status == 200 else None
+
+
+def _deps(version_result, package_result=None):
+    kd = KospexDependencies(kospex_query=_StubQuery(version_result, package_result))
+    return kd
+
+
+def test_depsdev_record_no_version():
+    rec = _deps((None, None)).depsdev_record("pypi", "foo", "")
+    assert rec["resolution"] == "no_version" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_unresolved_spec():
+    rec = _deps((None, None)).depsdev_record("npm", "chartjs", "^4.4.0")
+    assert rec["resolution"] == "unresolved_spec" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_package_not_found():
+    # exact version 404, package-level also 404
+    rec = _deps(version_result=(None, 404), package_result=(None, 404)).depsdev_record(
+        "pypi", "nope-typo", "1.0.0")
+    assert rec["resolution"] == "package_not_found" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_version_yanked():
+    # exact version 404, but package exists
+    rec = _deps(version_result=(None, 404), package_result=('{"versions": []}', 200)).depsdev_record(
+        "pypi", "realpkg", "9.9.9")
+    assert rec["resolution"] == "version_yanked" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_lookup_error():
+    rec = _deps(version_result=(None, None)).depsdev_record("pypi", "x", "1.0.0")
+    assert rec["resolution"] == "lookup_error" and rec["versions_behind"] is None
+
+
+def test_depsdev_record_resolved_versions_behind_is_int():
+    """get_versions_behind always returns an int in its 'versions_behind' key
+    (initialised to 0, only ever incremented) when the package-level fetch
+    succeeds, so the resolved path must carry a real int, never a sentinel
+    string like the old 'Unknown'/''."""
+    version_body = json.dumps({
+        "publishedAt": "2024-01-01T00:00:00Z",
+        "isDefault": True,
+        "links": [],
+        "advisoryKeys": [],
+    })
+    package_body = json.dumps({
+        "versions": [
+            {"isDefault": True, "publishedAt": "2024-01-01T00:00:00Z",
+             "versionKey": {"version": "1.0.0"}},
+        ]
+    })
+    rec = _deps(version_result=(version_body, 200),
+                package_result=(package_body, 200)).depsdev_record("pypi", "foo", "1.0.0")
+    assert rec["resolution"] == "resolved"
+    assert type(rec["versions_behind"]) is int
+    assert rec["versions_behind"] == 0

--- a/tests/test_resolution_status.py
+++ b/tests/test_resolution_status.py
@@ -1,0 +1,73 @@
+"""Tests for dependency resolution-status classification."""
+import sqlite_utils
+import kospex_schema as KospexSchema
+from kospex_query import KospexQuery
+
+
+def _kq():
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_URL_CACHE)
+    return KospexQuery(kospex_db=db)
+
+
+def test_url_request_with_status_200_returns_body_and_caches(monkeypatch):
+    kq = _kq()
+
+    class _Resp:
+        status_code = 200
+        text = '{"ok": true}'
+        def raise_for_status(self): pass
+
+    monkeypatch.setattr("kospex_query.requests.get", lambda *a, **k: _Resp())
+    content, status = kq.url_request_with_status("http://x/pkg")
+    assert status == 200 and content == '{"ok": true}'
+    # cached: a second call with requests.get patched to blow up still returns it
+    monkeypatch.setattr("kospex_query.requests.get",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should be cached")))
+    content2, status2 = kq.url_request_with_status("http://x/pkg")
+    assert status2 == 200 and content2 == '{"ok": true}'
+
+
+def test_url_request_with_status_404(monkeypatch):
+    import requests
+    kq = _kq()
+
+    class _Resp:
+        status_code = 404
+        text = "not found"
+        def raise_for_status(self):
+            raise requests.HTTPError(response=self)
+
+    monkeypatch.setattr("kospex_query.requests.get", lambda *a, **k: _Resp())
+    content, status = kq.url_request_with_status("http://x/missing")
+    assert content is None and status == 404
+
+
+def test_url_request_with_status_network_error(monkeypatch):
+    import requests
+    kq = _kq()
+    def _boom(*a, **k):
+        raise requests.ConnectionError("down")
+    monkeypatch.setattr("kospex_query.requests.get", _boom)
+    content, status = kq.url_request_with_status("http://x/err")
+    assert content is None and status is None
+
+
+def test_url_request_still_returns_bare_content(monkeypatch):
+    """url_request delegates to url_request_with_status but keeps its old
+    contract: bare content on success, None on failure (no tuple)."""
+    import requests
+    kq = _kq()
+
+    class _Resp:
+        status_code = 200
+        text = '{"ok": true}'
+        def raise_for_status(self): pass
+
+    monkeypatch.setattr("kospex_query.requests.get", lambda *a, **k: _Resp())
+    assert kq.url_request("http://x/pkg") == '{"ok": true}'
+
+    def _boom(*a, **k):
+        raise requests.ConnectionError("down")
+    monkeypatch.setattr("kospex_query.requests.get", _boom)
+    assert kq.url_request("http://x/err") is None

--- a/tests/test_resolution_status.py
+++ b/tests/test_resolution_status.py
@@ -71,3 +71,17 @@ def test_url_request_still_returns_bare_content(monkeypatch):
         raise requests.ConnectionError("down")
     monkeypatch.setattr("kospex_query.requests.get", _boom)
     assert kq.url_request("http://x/err") is None
+
+
+import pytest
+from kospex_dependencies import KospexDependencies
+
+
+@pytest.mark.parametrize("v,expected", [
+    ("1.2.3", True), ("0.0.16", True), ("2.0.0rc1", True), ("1.2.3-beta.1", True),
+    ("", False), (None, False), ("^4.4.0", False), (">=1.0,<2.0", False),
+    ("~1.2", False), ("1.x", False), ("latest", False), ("*", False),
+    ("workspace:*", False), ("https://github.com/o/r", False), ("git+https://x", False),
+])
+def test_is_concrete_version(v, expected):
+    assert KospexDependencies().is_concrete_version(v) is expected


### PR DESCRIPTION
## Overview

When kospex enriches a dependency via deps.dev, the lookup can come back empty. Previously that was flattened to `versions_behind = "Unknown"` (from `krunner osi`) or `""` (from `sca`) — one opaque bucket that lost the *reason* and had crashed the `/dependencies/` page (patched minimally in #105). This branch categorises **why** each lookup failed into a queryable `dependency_data.resolution` column, normalises `versions_behind` to int-or-NULL, logs every non-resolved outcome, and surfaces the category on `/dependencies/`.

Spec + plan: `changes/202607-dependency-resolution-status.md` and `-plan.md`.

## Resolution categories

| `resolution` | meaning | `versions_behind` |
|---|---|---|
| `resolved` | deps.dev knew the exact version | integer (0 = up to date) |
| `no_version` | dependency had no version to look up | NULL |
| `unresolved_spec` | not a concrete version (`^1.0`, git URL, `workspace:*`, `latest`, …) | NULL |
| `version_yanked` | package exists on deps.dev but that version doesn't | NULL |
| `package_not_found` | package itself isn't on deps.dev (typo / private / removed) | NULL |
| `lookup_error` | transient deps.dev failure (5xx / timeout / non-404) | NULL |
| `NULL` | legacy row, not yet re-classified | as-was |

## What changed

- **Migration `0005`** adds `dependency_data.resolution TEXT` (nullable; additive, no backfill).
- **`KospexQuery.url_request_with_status()`** — status-aware deps.dev fetch (splits 404 from network error). `url_request()` refactored to a thin wrapper delegating to it (single copy of the cache/fetch/upsert logic; `headers` now actually reaches `requests.get`).
- **`KospexDependencies.is_concrete_version()`** — pre-call gate distinguishing a concrete version from a spec/range/URL/keyword; `packaging` added to `pyproject.toml`.
- **`depsdev_record()`** runs the classification decision tree at the shared enrichment seam, so both `krunner osi` and `assess()` inherit `resolution` + int/None `versions_behind`. Every non-resolved outcome is logged at INFO.
- **`/dependencies/`** shows a gray category badge for the five failure categories, else the orange numeric count, else green "Up to date" (preserving the #105 `is number` guard). Legacy NULL-resolution rows render exactly as post-#105.
- **`/package-check/upload`** hardened: the new explicit `None` `versions_behind` was crashing its status loop (`None > 6` → 500); extracted into a pure `_classify_upload_status()` helper that coalesces None and surfaces an honest status for unresolved deps.

## Deploy note

Both DB-writing paths now emit `resolution` on every row, so **`kospex upgrade-db -apply` must be run before the upgraded code writes dependencies** (a DB still on the old schema fails with `no such column: resolution`). Documented in the changes doc.

## Testing

390 tests pass. New coverage: migration `0005`, `url_request_with_status` (200/404/network), `is_concrete_version` (15 cases), all six classifier branches (404-package-exists vs missing genuinely distinguished), `save_dependencies` round-trip of `resolution`, the `/dependencies/` badge precedence, and 7 `/package-check/upload` tests (TestClient reproduction of the 500 + helper precedence).

## Depends on / relates to

Builds on #105 (the `/dependencies/` template guard) — already merged into the base.

## Follow-ups (out of scope, pre-existing)

- `nuget_assess` has no `return` and `assess()` doesn't capture its result, so nuget deps are never persisted by `assess()` (two bugs deep).
- Unparseable `requirements.txt` lines in `pypi_assess` bypass `depsdev_record` (no version to classify — consistent NULL, not a half-wire).
- `supply_chain.html` colours a now-`null` `versions_behind` as green; map resolution/null to a distinct "unknown" colour if that view is revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
