### PR TITLE
docs: fix site-wide broken links in nav/footer

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -34,10 +34,10 @@
                     <ul class="nav-menu">
                         <li><a href="/">Home</a></li>
                         <li><a href="/getting-started">Getting Started</a></li>
-                        <li><a href="/articles/">Articles</a></li>
+                        <li><a href="https://kospex.io/articles/">Articles</a></li>
                         <li><a href="/troubleshooting">Troubleshooting</a></li>
                         <li>
-                            <a href="https://kospex.io/contact-us.html"
+                            <a href="https://kospex.io/contact-us/"
                                 >Contact</a
                             >
                         </li>
@@ -85,14 +85,14 @@
                             <li><a href="/getting-started">Getting Started</a></li>
                             <li><a href="/use-cases">Use Cases</a></li>
                             <li><a href="/commands">Commands</a></li>
-                            <li><a href="https://kospex.io/contact-us.html">Contact</a></li>
+                            <li><a href="https://kospex.io/contact-us/">Contact</a></li>
                         </ul>
                     </div>
                     <div class="footer-links">
                         <h4>Resources</h4>
                         <ul>
                             <li><a href="/">Documentation</a></li>
-                            <li><a href="/articles/">Articles</a></li>
+                            <li><a href="https://kospex.io/articles/">Articles</a></li>
                             <li>
                                 <a
                                     href="https://github.com/kospex/"
@@ -100,8 +100,6 @@
                                     >GitHub</a
                                 >
                             </li>
-                            <li><a href="https://kospex.io/privacy-policy.html">Privacy Policy</a></li>
-                            <li><a href="https://kospex.io/terms-of-service.html">Terms of Service</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
Follow-up to #111. A full link crawl of docs.kospex.io (30 links across 15 pages) surfaced broken links in the shared `_layouts/default.html`, so they showed on **every** docs page.

| Link | Status | Fix |
|---|---|---|
| `/articles/` (nav + footer) | 404 — no articles index on docs | → `https://kospex.io/articles/` |
| `kospex.io/privacy-policy.html` (footer) | 404 — never existed | removed |
| `kospex.io/terms-of-service.html` (footer) | 404 — never existed | removed |
| `kospex.io/contact-us.html` (nav + footer) | 200 but via 301 | → `https://kospex.io/contact-us/` (direct) |

### Notes
- The article redirect stubs from #111 are live and verified (canonical + meta-refresh to kospex.io).
- `favicon.ico` showed up in the scan but is a **false positive** — it's a commented-out line in the slate theme's default head. Neither site has a real favicon (minor branding gap, out of scope here).
- Privacy/Terms pages don't exist anywhere. Removing the dead links is the correct fix; creating real legal pages is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)