### PR TITLE
fix(git): /osi/ 'last commit: None' from doubled slash in rename parsing

### DIFF
--- a/src/kospex_utils.py
+++ b/src/kospex_utils.py
@@ -625,6 +625,16 @@ def parse_git_rename_event(event_str):
         old, new = extract_git_rename_values(rename)
         event_str = event_str.replace(rename, new)
 
+    if renames:
+        # A directory-level rename (a file moved up/down a level) renders with
+        # an empty brace side, e.g. ".github/{workflows => }/dependabot.yml".
+        # Substituting the empty side leaves a doubled slash (or a leading
+        # slash when the file moved to the repo root); collapse to the
+        # canonical repo-relative path so it matches the working-tree path.
+        # Guarded on `renames` so non-rename inputs (including legitimate
+        # leading-slash paths) are returned untouched.
+        event_str = re.sub(r"/{2,}", "/", event_str).lstrip("/")
+
     return event_str
 
 #def parse_git_rename_event(event_str):

--- a/tests/test_kospex.py
+++ b/tests/test_kospex.py
@@ -58,6 +58,22 @@ def test_git_rename_event():
     expected = 'utilities/developer_utils/cookiecutter/static/css/{{cookiecutter.app_name}}.css'
     assert expected == KospexUtils.parse_git_rename_event(replace_and_2braces)
 
+
+def test_git_rename_event_empty_brace_side():
+    """A directory-level rename renders in git --numstat with an empty brace
+    side (the file moved up/down a level). Expanding the empty side must not
+    leave a doubled or leading slash, or the resulting path won't match the
+    working-tree path and file_metadata.committer_when ends up NULL."""
+    # File moved up a level: ".github/workflows/dependabot.yml" -> ".github/dependabot.yml"
+    assert KospexUtils.parse_git_rename_event(
+        ".github/{workflows => }/dependabot.yml") == ".github/dependabot.yml"
+    # File moved to repo root: "docs/README.md" -> "README.md"
+    assert KospexUtils.parse_git_rename_event("{docs => }/README.md") == "README.md"
+    # Empty side at the start (added dir level) still resolves cleanly
+    assert KospexUtils.parse_git_rename_event("{ => src}/foo.js") == "src/foo.js"
+    # Both-sides-present renames are unaffected
+    assert KospexUtils.parse_git_rename_event("pkg/{old => new}/x.py") == "pkg/new/x.py"
+
 def test_days_functions():
     """ Test the days calculation functions """
 


### PR DESCRIPTION
## Symptom

`/osi/` shows some dependency files with a **last commit of `None`** — e.g. `expressjs/express`'s `.github/dependabot.yml`.

## Root cause

`/osi/` renders "last commit" from `file_metadata.committer_when`. That column is set in `build_file_metadata_rows` by matching each file's working-tree path (from panopticas) against `commit_files.file_path` (parsed from `git log --numstat`) by **exact string**. On a miss it leaves `committer_when = None` (and falls the hash back to repo HEAD).

`git log --numstat` renders a **directory-level rename** — a file moved up or down a level — with an **empty brace side**, e.g. when `.github/workflows/dependabot.yml` moved to `.github/dependabot.yml`:

```
.github/{workflows => }/dependabot.yml
```

`parse_git_rename_event` substituted the empty side with `event_str.replace("{workflows => }", "")`, which removed the segment but left both surrounding slashes:

```
.github//dependabot.yml      # doubled slash
```

That malformed path is stored in `commit_files`, never matches panopticas's clean `.github/dependabot.yml`, so `committer_when` stays `None`.

Repo-wide this accounts for the double-slash class of `None` rows (~110 files across many repos: jquery, pytest, airbnb/lottie, …). Only 2 are dependency files, which is why only 2 are visible on `/osi/`.

## Fix

Collapse repeated slashes (and a resulting leading slash, for a move to the repo root) after the rename substitution, **guarded on `renames`** so non-rename inputs — including a legitimately leading-slash path that an existing test pins — are returned untouched.

```python
if renames:
    event_str = re.sub(r"/{2,}", "/", event_str).lstrip("/")
```

## Tests

New `test_git_rename_event_empty_brace_side` (RED reproduced `.github//dependabot.yml`; GREEN after). The existing `test_git_rename_event` — including its leading-slash-preservation and double-brace-jinja cases — still passes. Full suite: **419 passed**.

## Note

This corrects **future** syncs. Rows already stored with `//` paths clear on the next `kospex sync` of the affected repo.

## Not in scope (follow-up)

The other, unrelated class of `None` rows — **unicode filenames** that git *quotes* in `--numstat` output (e.g. `♪.md`, `test-ϋnicodé…`) — is a separate parser issue (path quoting) still to be traced. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
