### PR TITLE
feat(web): /osi/ per-file Extracted? status + extraction-coverage commentary (sub-project B)

### DIFF
--- a/changes/2026-07-20-osi-extraction-status-design.md
+++ b/changes/2026-07-20-osi-extraction-status-design.md
@@ -1,0 +1,86 @@
+# `/osi/` extraction status — design
+
+**Date:** 2026-07-20
+**Status:** Approved (design) — ready for implementation plan
+**Sub-project:** B of the 4-part extractor program (A registry+classifier ✅ merged · **B `/osi/` display** · C scanner parity · D new extractors)
+
+## Motivation
+
+`/osi/` lists the dependency files kospex has discovered but says nothing about whether kospex has actually pulled the dependencies *out* of each one. A reader can't tell a `package.json` we parsed into 40 enriched dependencies from a `yarn.lock` we can't parse at all — both are just rows. Sub-project A shipped `kospex.extractors.registry.classify()`; this surfaces it on `/osi/`.
+
+The signal a user wants is **realized, per file**: *have we extracted dependency details from this file?* — not the abstract "is this file type supported." Those are different axes (see below), and only the realized one goes on the page.
+
+## Definitions (the two axes, kept distinct)
+
+- **Extracted (realized, per file):** `dependency_data` holds `latest=1` rows for this exact `(_repo_id, file_path)`. Yes = kospex parsed this file into dependency records (and enriched the package ones via deps.dev). This is the **only** new per-file signal shown.
+- **Supported (capability, per type):** a parser exists for this file *type* (`classify().supported == bool(scanners)`). Does **not** imply we ran it. A supported type can be un-extracted because the repo was never scanned. Used **only** behind the scenes to explain the No's in the commentary — never shown as its own column.
+
+`classify()` assumes a `|dependencies|`-tagged filename; `/osi/`'s `get_dependency_files` already filters to exactly that, so every row is valid input.
+
+## Scope
+
+**In:**
+- One new **"Extracted?"** column on the Individual Files table (Yes/No, realized).
+- A **commentary callout above the tables** naming, grouped by kind, the file types with no extracted details — using `classify()` for the *why*.
+- The route computation + a pure aggregation helper + one query method, all unit-testable.
+
+**Out (unchanged / deferred):**
+- The dev-status count table, the "N files found" line, and the Dependency File Summary table — untouched (YAGNI).
+- **Staleness** — `/osi/` reflects whatever the last `krunner osi` / `kospex sca` captured; it does not trigger extraction. The "supported but not scanned" commentary bucket *surfaces* this; auto-refresh/trigger is a later concern (noted, not built).
+- **N5 (umbrella with a separate actions interface)** and **N6 (kind-based drill-down to `/cicd/`)** from the A design — still deferred; the actions interface does not exist. Package-kind rows keep their existing `/dependencies/{repo_id}` link.
+- No schema change.
+
+## Data flow (route: `kweb2.py` `osi()`)
+
+Today the route builds `deps` (file_metadata rows, each with `_repo_id` + `Provider`) and derives `status` / `dep_files`. It gains three steps before rendering:
+
+1. **Realized-extracted set** — `extracted_keys = KospexQuery().extracted_dependency_file_keys(request_id)` → a `set` of `(_repo_id, file_path)` that have `latest=1` rows in `dependency_data`, scoped to the same `request_id`. (`dependency_data.file_path` equals `file_metadata.Provider` for the same file — this is the join already used to count 416 assessed files.)
+2. **Annotate + aggregate** — `annotated, commentary = KospexWeb.osi_extraction_view(deps, extracted_keys)` (pure helper, below). Sets `file["extracted"] = True/False` on each row and builds the commentary buckets.
+3. Pass `commentary` into the template context alongside the existing keys; `deps` now carries the `extracted` flag per row.
+
+### Pure helper — `KospexWeb.osi_extraction_view(files, extracted_keys)`
+
+Module-level/staticmethod in `kospex_web.py` (pure — no DB, no request), so it is unit-tested with synthetic inputs.
+
+- Input: `files` (list of dicts with `_repo_id`, `Provider`), `extracted_keys` (set of `(_repo_id, file_path)`).
+- For each file: `file["extracted"] = (file["_repo_id"], file["Provider"]) in extracted_keys`.
+- For every **not-extracted** file, call `classify(file["Provider"])` and bucket:
+  - **`no_parser`** — `classify.supported is False`: keyed by kind's **string value** (`classify.kind.value`, e.g. `"package"`, `"container"`), then by file **basename** (`os.path.basename(file["Provider"])`, e.g. `"yarn.lock"` — not the full path `pydantic-core/uv.lock`): `{ "package": {"yarn.lock": 49, "uv.lock": 22}, "container": {"Dockerfile": 12} }`.
+  - **`not_scanned`** — `classify.supported is True`: a single integer count (supported types we simply haven't scanned).
+- Returns `(files, commentary)` where `commentary = {"no_parser": {<kind>: {<basename>: <count>}}, "not_scanned": <int>}`. Both buckets are ordinary dicts/ints so the template can iterate them directly.
+
+Return shape is deliberately template-ready: the callout iterates `no_parser` by kind and prints the `not_scanned` count.
+
+## What `/osi/` shows
+
+- **Commentary callout** (new card, placed above "Dependency File Status"): title *"Dependency extraction coverage."*
+  - If `no_parser` is non-empty: *"Not extracted — no parser yet:"* then, grouped by kind, the file types with counts (`yarn.lock (49)`, `uv.lock (22)`; runtime: `.python-version`; container: `Dockerfile` …).
+  - If `not_scanned > 0`: *"N supported files not yet scanned — run `kospex sca` / `krunner osi` to extract them."*
+  - If both empty: a single line *"All discovered dependency files have extracted details."*
+- **Individual Files table** gains an **"Extracted?"** column: a green **Yes** badge (the Repo cell already links to `/dependencies/{repo_id}` where those details live) or a gray **No** badge. Caption under the table: *"'Extracted?' = kospex has parsed and enriched dependency details from this file."*
+- Everything else on the page is unchanged.
+
+## Query — `KospexQuery.extracted_dependency_file_keys(request_id)`
+
+Mirrors the scoping of `get_dependencies` (repo_id / org_key / server), returns a `set` of `(_repo_id, file_path)`:
+
+```sql
+SELECT DISTINCT _repo_id, file_path FROM dependency_data WHERE latest = 1 [ + scope ]
+```
+
+## Files
+
+- `src/kweb2.py` — `osi()` route: two new calls + pass `commentary`.
+- `src/kospex_web.py` — new pure `osi_extraction_view(files, extracted_keys)`.
+- `src/kospex_query.py` — new `extracted_dependency_file_keys(request_id)`.
+- `src/templates/osi.html` — commentary callout + "Extracted?" column + caption.
+
+## Testing
+
+- **`osi_extraction_view` unit tests** (pure, synthetic files — no DB/server): an extracted file → `extracted=True`, not in any bucket; a not-extracted supported file (`package.json`) → `extracted=False`, counted in `not_scanned`; an unsupported manifest (`yarn.lock`) → `no_parser["package"]["yarn.lock"] == 1`; a `Dockerfile` → `no_parser["container"]`; the all-extracted case → both buckets empty.
+- **Template render** (in-process, the `test_dependencies_template.py` pattern): render `osi.html` with rows for each state + a sample commentary → the "Extracted?" Yes/No badges appear, the callout names `yarn.lock` and shows the `not_scanned` count, and the all-extracted case shows the "all extracted" line. No crash.
+- **Query test** — against an in-memory DB with a `dependency_data` fixture: `extracted_dependency_file_keys` returns exactly the `latest=1` `(_repo_id, file_path)` pairs, honouring scope.
+
+## Boundary
+
+B stops at *surfacing* extraction status honestly. It does not add parsers (D), route scanners through the registry (C), trigger extraction, or build the actions/`cicd` surface (N4–N6). Package rows keep the existing `/dependencies/` drill-through.

--- a/changes/2026-07-20-osi-extraction-status-plan.md
+++ b/changes/2026-07-20-osi-extraction-status-plan.md
@@ -1,0 +1,403 @@
+# `/osi/` Extraction Status — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show on `/osi/` whether kospex has extracted dependency details from each file (a per-file "Extracted?" column) plus a `classify()`-driven commentary grouping the file types with no extracted details by kind.
+
+**Architecture:** Three small additive pieces — a scoped query returning the set of `(_repo_id, file_path)` that have extracted `dependency_data` rows; a pure `osi_extraction_view` helper that annotates each file with `extracted` and builds the commentary buckets (using the merged `classify()`); and the `osi()` route + `osi.html` wiring that renders them. No schema change.
+
+**Tech Stack:** Python 3.12, FastAPI + Jinja2, `sqlite_utils`, `KospexData` query builder, `kospex.extractors.registry.classify`, pytest.
+
+**Design:** `changes/2026-07-20-osi-extraction-status-design.md`.
+
+## Global Constraints
+
+- **Additive only.** Touch `src/kospex_query.py`, `src/kospex_web.py`, `src/kweb2.py`, `src/templates/osi.html`, and their tests. No schema change; no change to the dev-status table, the "N files found" line, or the Dependency File Summary table.
+- **`kospex_web.py` is a module of functions** (imported as `import kospex_web as KospexWeb`, called `KospexWeb.func(...)`) — NOT a class. The new helper is a module-level function.
+- **The helper is pure**: no DB, no request object, no I/O. It takes `files` and `extracted_keys` and returns `(files, commentary)`. This is what makes it unit-testable.
+- **"Extracted?" is realized, per file**: `True` iff `(_repo_id, file_path)` has a `latest=1` row in `dependency_data`. `dependency_data.file_path` equals `file_metadata.Provider` for the same file.
+- **`classify()` (kind + supported) is used ONLY to build the commentary** — never shown as its own column. `supported == bool(scanners)` is capability (a parser exists for the type), distinct from realized extraction.
+- **`commentary` shape** (template-ready): `{"no_parser": {<kind_value>: {<basename>: <count>}}, "not_scanned": <int>}`. `no_parser` keys are `classify.kind.value` strings then file **basenames**; `not_scanned` counts supported-type files that simply weren't scanned.
+- Python 3.12. Run tests from the worktree root: `PYTHONPATH=$PWD/src python -m pytest <path> -p no:cacheprovider`.
+- **Execution:** on a fresh git worktree branched off current `main` (subagent-driven-development).
+
+---
+
+## Task 1: `KospexQuery.extracted_dependency_file_keys`
+
+**Files:**
+- Modify: `src/kospex_query.py` (add a method to `KospexQuery`, near `get_dependencies` ~line 262)
+- Test: `tests/test_extracted_file_keys.py` (create)
+
+**Interfaces:**
+- Consumes: `KospexData` (already in the module), `KospexSchema.TBL_DEPENDENCY_DATA`.
+- Produces: `KospexQuery.extracted_dependency_file_keys(request_id=None) -> set[tuple[str, str]]` — the set of `(_repo_id, file_path)` with `latest=1` rows in `dependency_data`, scoped like `get_dependencies`.
+
+- [ ] **Step 1: Write the failing test.** Create `tests/test_extracted_file_keys.py`:
+
+```python
+"""Tests for KospexQuery.extracted_dependency_file_keys (sub-project B)."""
+import sqlite_utils
+import kospex_schema as KospexSchema
+from kospex_query import KospexQuery
+
+
+def _kq_with_rows(rows):
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    for r in rows:
+        db["dependency_data"].insert(r, pk=["_repo_id", "hash", "file_path",
+                                            "package_type", "package_name",
+                                            "package_version"], alter=True)
+    return KospexQuery(kospex_db=db)
+
+
+def test_returns_latest_repo_file_pairs():
+    kq = _kq_with_rows([
+        {"_repo_id": "s~o~r", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "a", "package_version": "1", "latest": 1},
+        {"_repo_id": "s~o~r", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "b", "package_version": "2", "latest": 1},
+        {"_repo_id": "s~o~r", "hash": "h2", "file_path": "package.json",
+         "package_type": "npm", "package_name": "c", "package_version": "3", "latest": 1},
+        {"_repo_id": "s~o~old", "hash": "h3", "file_path": "old.txt",
+         "package_type": "pypi", "package_name": "d", "package_version": "4", "latest": 0},
+    ])
+    keys = kq.extracted_dependency_file_keys()
+    assert keys == {("s~o~r", "requirements.txt"), ("s~o~r", "package.json")}
+    assert isinstance(keys, set)
+
+
+def test_scoped_by_repo_id():
+    kq = _kq_with_rows([
+        {"_repo_id": "s~o~r1", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "a", "package_version": "1", "latest": 1},
+        {"_repo_id": "s~o~r2", "hash": "h2", "file_path": "package.json",
+         "package_type": "npm", "package_name": "c", "package_version": "3", "latest": 1},
+    ])
+    keys = kq.extracted_dependency_file_keys({"repo_id": "s~o~r1"})
+    assert keys == {("s~o~r1", "requirements.txt")}
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/test_extracted_file_keys.py -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: 'KospexQuery' object has no attribute 'extracted_dependency_file_keys'`.
+
+- [ ] **Step 3: Implement.** Add to the `KospexQuery` class in `src/kospex_query.py` (immediately after `get_dependencies`):
+
+```python
+    def extracted_dependency_file_keys(self, request_id=None):
+        """Return the set of (repo_id, file_path) that have extracted dependency
+        rows (latest=1) in dependency_data, scoped like get_dependencies. Used by
+        /osi/ to mark which discovered files kospex has actually parsed."""
+        kd = KospexData(self.kospex_db)
+        kd.from_table(KospexSchema.TBL_DEPENDENCY_DATA)
+        kd.select("_repo_id", "file_path")
+        kd.where("latest", "=", 1)
+
+        if request_id:
+            if repo_id := request_id.get("repo_id"):
+                kd.where("_repo_id", "=", repo_id)
+            elif org_key := request_id.get("org_key"):
+                kd.where_org_key(org_key)
+            elif server := request_id.get("server"):
+                kd.where("_git_server", "=", server)
+
+        return {(row["_repo_id"], row["file_path"]) for row in kd.execute()}
+```
+
+- [ ] **Step 4: Run test to verify it passes.** Same command as Step 2. Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/kospex_query.py tests/test_extracted_file_keys.py
+git commit -m "feat(query): extracted_dependency_file_keys for /osi/ extraction status"
+```
+
+---
+
+## Task 2: `KospexWeb.osi_extraction_view` (pure helper)
+
+**Files:**
+- Modify: `src/kospex_web.py` (add a module-level function; add the `classify` import)
+- Test: `tests/test_osi_extraction_view.py` (create)
+
+**Interfaces:**
+- Consumes: `kospex.extractors.registry.classify` (pure, merged in sub-project A). `classify(name)` returns an object with `.supported: bool` and `.kind` (a `Kind` enum whose `.value` is the string).
+- Produces: `kospex_web.osi_extraction_view(files, extracted_keys) -> tuple[list, dict]`. Mutates each file dict in `files` to add `file["extracted"] = bool` and returns `(files, commentary)` with `commentary = {"no_parser": {kind_value: {basename: count}}, "not_scanned": int}`.
+
+- [ ] **Step 1: Write the failing test.** Create `tests/test_osi_extraction_view.py`:
+
+```python
+"""Tests for kospex_web.osi_extraction_view (sub-project B)."""
+import kospex_web as KospexWeb
+
+
+def _f(repo, provider, filename=None):
+    return {"_repo_id": repo, "Provider": provider,
+            "Filename": filename or provider.rsplit("/", 1)[-1]}
+
+
+def test_marks_extracted_and_buckets_the_rest():
+    files = [
+        _f("s~o~r", "requirements.txt"),              # extracted (supported)
+        _f("s~o~r", "package.json"),                  # NOT extracted, supported -> not_scanned
+        _f("s~o~r", "yarn.lock"),                     # NOT extracted, no parser -> no_parser[package]
+        _f("s~o~r", "sub/uv.lock", "uv.lock"),        # NOT extracted, no parser -> no_parser[package]
+        _f("s~o~r", ".github/Dockerfile", "Dockerfile"),  # NOT extracted -> no_parser[container]
+    ]
+    extracted = {("s~o~r", "requirements.txt")}
+
+    out_files, commentary = KospexWeb.osi_extraction_view(files, extracted)
+
+    by_provider = {f["Provider"]: f["extracted"] for f in out_files}
+    assert by_provider["requirements.txt"] is True
+    assert by_provider["package.json"] is False
+    assert by_provider["yarn.lock"] is False
+
+    assert commentary["no_parser"]["package"] == {"yarn.lock": 1, "uv.lock": 1}
+    assert commentary["no_parser"]["container"] == {"Dockerfile": 1}
+    assert commentary["not_scanned"] == 1  # the package.json
+
+
+def test_all_extracted_gives_empty_commentary():
+    files = [_f("s~o~r", "requirements.txt"), _f("s~o~r", "package.json")]
+    extracted = {("s~o~r", "requirements.txt"), ("s~o~r", "package.json")}
+    out_files, commentary = KospexWeb.osi_extraction_view(files, extracted)
+    assert all(f["extracted"] for f in out_files)
+    assert commentary == {"no_parser": {}, "not_scanned": 0}
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/test_osi_extraction_view.py -p no:cacheprovider -q`
+Expected: FAIL — `AttributeError: module 'kospex_web' has no attribute 'osi_extraction_view'`.
+
+- [ ] **Step 3: Implement.** At the top of `src/kospex_web.py`, add the import (alongside the existing imports):
+
+```python
+import os
+from kospex.extractors.registry import classify
+```
+
+(If `import os` is already present, do not duplicate it.) Then add this module-level function:
+
+```python
+def osi_extraction_view(files, extracted_keys):
+    """Annotate /osi/ dependency files with realized extraction status and build
+    the commentary buckets.
+
+    files: list of file_metadata dicts (each with _repo_id and Provider).
+    extracted_keys: set of (repo_id, file_path) that have extracted dependency rows.
+
+    Sets file["extracted"] = True/False on each file. Returns (files, commentary)
+    where commentary = {"no_parser": {kind_value: {basename: count}}, "not_scanned": int}:
+      - no_parser: not-extracted files whose type has no parser (classify.supported False),
+        grouped by kind then basename.
+      - not_scanned: count of not-extracted files whose type IS supported (just not scanned).
+    """
+    no_parser = {}
+    not_scanned = 0
+
+    for f in files:
+        key = (f.get("_repo_id"), f.get("Provider"))
+        extracted = key in extracted_keys
+        f["extracted"] = extracted
+        if extracted:
+            continue
+
+        result = classify(f.get("Provider") or "")
+        if result.supported:
+            not_scanned += 1
+        else:
+            basename = os.path.basename(f.get("Provider") or "")
+            kind = result.kind.value
+            no_parser.setdefault(kind, {})
+            no_parser[kind][basename] = no_parser[kind].get(basename, 0) + 1
+
+    return files, {"no_parser": no_parser, "not_scanned": not_scanned}
+```
+
+- [ ] **Step 4: Run test to verify it passes.** Same command as Step 2. Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/kospex_web.py tests/test_osi_extraction_view.py
+git commit -m "feat(web): osi_extraction_view helper (extracted flag + commentary buckets)"
+```
+
+---
+
+## Task 3: `osi()` route wiring + `osi.html` + render test
+
+**Files:**
+- Modify: `src/kweb2.py` (the `osi()` route, ~line 478-502)
+- Modify: `src/templates/osi.html` (commentary callout + "Extracted?" column + caption)
+- Test: `tests/test_osi_template.py` (create)
+
+**Interfaces:**
+- Consumes: `KospexQuery.extracted_dependency_file_keys` (Task 1) and `KospexWeb.osi_extraction_view` (Task 2). `KospexWeb` is already imported in `kweb2.py` as `import kospex_web as KospexWeb`; `KospexQuery` is already used in the route.
+- Produces: the rendered `/osi/` page with the new column and callout. Template context gains `commentary`; each `data` row gains `extracted`.
+
+- [ ] **Step 1: Write the failing test.** Create `tests/test_osi_template.py`:
+
+```python
+"""Render tests for the /osi/ page (sub-project B)."""
+import kweb2
+
+
+def _render(context):
+    tmpl = kweb2.templates.get_template("osi.html")
+    base = {"request": None, "data": [], "file_number": 0,
+            "dep_files": [], "status": {}, "commentary": {"no_parser": {}, "not_scanned": 0}}
+    base.update(context)
+    return tmpl.render(base)
+
+
+def test_extracted_badges_and_commentary():
+    rows = [
+        {"_repo_id": "s~o~r", "_git_repo": "r", "Provider": "requirements.txt",
+         "committer_when": "2025-01-01", "status": "Active", "days_ago": 1, "extracted": True},
+        {"_repo_id": "s~o~r", "_git_repo": "r", "Provider": "yarn.lock",
+         "committer_when": "2025-01-01", "status": "Active", "days_ago": 1, "extracted": False},
+    ]
+    commentary = {"no_parser": {"package": {"yarn.lock": 49}, "container": {"Dockerfile": 3}},
+                  "not_scanned": 5}
+    html = _render({"data": rows, "file_number": 2, "commentary": commentary})
+    assert "Extracted?" in html          # new column header
+    assert "Yes" in html and "No" in html
+    assert "yarn.lock" in html and "49" in html   # commentary names the type + count
+    assert "not yet scanned" in html.lower()      # the not_scanned line
+
+
+def test_all_extracted_message():
+    html = _render({"commentary": {"no_parser": {}, "not_scanned": 0}})
+    assert "all discovered dependency files have extracted details" in html.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails.**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/test_osi_template.py -p no:cacheprovider -q`
+Expected: FAIL — `assert "Extracted?" in html` fails (column/callout not in the template yet).
+
+- [ ] **Step 3a: Add the commentary callout to `src/templates/osi.html`.** Insert this block immediately after `{% include '_header.html' %}` block's containing `<div class="container mx-auto px-4 mt-12">` opens and BEFORE the `<!-- Page Header -->` div (i.e. as the first card inside the container). Place it right after line `<div class="container mx-auto px-4 mt-12">`:
+
+```html
+            <!-- Dependency Extraction Coverage -->
+            <div class="bg-white border border-gray-200 rounded-lg shadow-sm mb-8">
+                <div class="p-6">
+                    <h2 class="text-2xl font-bold text-gray-900 mb-4">
+                        Dependency extraction coverage
+                    </h2>
+                    {% if commentary and (commentary['no_parser'] or commentary['not_scanned']) %}
+                        {% if commentary['no_parser'] %}
+                        <p class="text-gray-700 mb-2">Not extracted — no parser yet:</p>
+                        <ul class="list-disc list-inside text-gray-700 mb-3">
+                            {% for kind, types in commentary['no_parser'].items() %}
+                            <li>
+                                <span class="font-semibold">{{ kind }}</span>:
+                                {% for name, count in types.items() %}{{ name }} ({{ count }}){% if not loop.last %}, {% endif %}{% endfor %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                        {% if commentary['not_scanned'] %}
+                        <p class="text-gray-700">
+                            {{ commentary['not_scanned'] }} supported file{{ 's' if commentary['not_scanned'] != 1 else '' }} not yet scanned — run <code>kospex sca</code> / <code>krunner osi</code> to extract them.
+                        </p>
+                        {% endif %}
+                    {% else %}
+                        <p class="text-gray-700">All discovered dependency files have extracted details.</p>
+                    {% endif %}
+                </div>
+            </div>
+```
+
+- [ ] **Step 3b: Add the "Extracted?" column to the Individual Files table.** In the `#myTable` `<thead>`, after the "Days Ago" `<th>` (the last header, ~line 227), add:
+
+```html
+                                    <th
+                                        class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                    >
+                                        Extracted?
+                                    </th>
+```
+
+In the `<tbody>` loop, after the "Days Ago" `<td>` (`{{ row.get('days_ago',"-") }}`, ~line 261), add:
+
+```html
+                                    <td
+                                        class="px-6 py-4 whitespace-nowrap text-sm text-center"
+                                    >
+                                        {% if row.get('extracted') %}
+                                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">Yes</span>
+                                        {% else %}
+                                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">No</span>
+                                        {% endif %}
+                                    </td>
+```
+
+(Appending as the final column keeps "Days Ago" at column index 4, so the DataTable `order: [[4, "asc"]]` on `#myTable` is unchanged.) Add a caption line right after the `</table>`'s closing `</div>` inside the Individual Files card, before that card's closing `</div>`:
+
+```html
+                    <p class="text-sm text-gray-500 mt-3">
+                        "Extracted?" = kospex has parsed and enriched dependency details from this file.
+                    </p>
+```
+
+- [ ] **Step 3c: Wire the route.** In `src/kweb2.py`, replace the body of `osi()` between `deps = KospexQuery().get_dependency_files(request_id=params)` and the `return templates.TemplateResponse(...)` so it computes the extraction view. The updated section:
+
+```python
+        params = KospexWeb.get_id_params(id)
+        deps = KospexQuery().get_dependency_files(request_id=params)
+
+        for file in deps:
+            file["days_ago"] = KospexUtils.days_ago(file.get("committer_when"))
+            file["status"] = KospexUtils.development_status(file.get("days_ago"))
+
+        extracted_keys = KospexQuery().extracted_dependency_file_keys(request_id=params)
+        deps, commentary = KospexWeb.osi_extraction_view(deps, extracted_keys)
+
+        file_number = len(deps)
+        status = KospexUtils.repo_stats(deps, "committer_when")
+        filenames = KospexUtils.filenames_by_repo_id(deps)
+
+        return templates.TemplateResponse(
+            request, "osi.html",
+            {
+                "data": deps,
+                "file_number": file_number,
+                "dep_files": filenames,
+                "status": status,
+                "commentary": commentary,
+            },
+        )
+```
+
+- [ ] **Step 4: Run the render test to verify it passes.**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest tests/test_osi_template.py -p no:cacheprovider -q`
+Expected: PASS (2 tests). If `_header.html`/`_datatable_scripts.html` includes raise on the `None` request, mirror how `tests/test_dependencies_template.py` handles context — but they render fine there with `request=None`, so no extra context should be needed.
+
+- [ ] **Step 5: Run the full suite.**
+
+Run: `PYTHONPATH=$PWD/src python -m pytest -p no:cacheprovider -q`
+Expected: PASS — pre-existing suite plus the three new test files, zero failures. (The 2 pre-existing `/osi/`/web live-server tests that need a running server are skipped without one — unchanged by this task.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/kweb2.py src/templates/osi.html tests/test_osi_template.py
+git commit -m "feat(web): show per-file Extracted? + extraction-coverage commentary on /osi/"
+```
+
+---
+
+## Self-review (author checklist — completed)
+
+- **Spec coverage:** "Extracted?" column ✓ (T3 template + T2 flag + T1 query). Commentary callout grouped by kind ✓ (T2 buckets + T3 template). Pure helper ✓ (T2). Scoped query ✓ (T1). All three testable without a live server ✓ (unit + in-process render). Deferrals (staleness, N4–N6, Summary/dev-status tables) require no code — untouched. No spec requirement is left without a task.
+- **Placeholder scan:** none — every step has runnable code/commands and expected output.
+- **Type consistency:** `extracted_dependency_file_keys(request_id) -> set[(repo_id, file_path)]` (T1) is consumed as `extracted_keys` by `osi_extraction_view(files, extracted_keys) -> (files, commentary)` (T2); the route (T3) passes T1's output to T2 and T2's `commentary` to the template. `commentary` shape `{"no_parser": {kind: {basename: count}}, "not_scanned": int}` is identical across T2's implementation, T2's test, and T3's template/test. `file["extracted"]` (bool) is set in T2 and read in T3's template.

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -284,6 +284,25 @@ class KospexQuery:
 
         return results
 
+    def extracted_dependency_file_keys(self, request_id=None):
+        """Return the set of (repo_id, file_path) that have extracted dependency
+        rows (latest=1) in dependency_data, scoped like get_dependencies. Used by
+        /osi/ to mark which discovered files kospex has actually parsed."""
+        kd = KospexData(self.kospex_db)
+        kd.from_table(KospexSchema.TBL_DEPENDENCY_DATA)
+        kd.select("_repo_id", "file_path")
+        kd.where("latest", "=", 1)
+
+        if request_id:
+            if repo_id := request_id.get("repo_id"):
+                kd.where("_repo_id", "=", repo_id)
+            elif org_key := request_id.get("org_key"):
+                kd.where_org_key(org_key)
+            elif server := request_id.get("server"):
+                kd.where("_git_server", "=", server)
+
+        return {(row["_repo_id"], row["file_path"]) for row in kd.execute()}
+
     def get_email_maps(self, alias=None, email=None):
         """
         Get the email maps for the given scope.

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -292,6 +292,7 @@ class KospexQuery:
         kd.from_table(KospexSchema.TBL_DEPENDENCY_DATA)
         kd.select("_repo_id", "file_path")
         kd.where("latest", "=", 1)
+        kd.group_by("_repo_id", "file_path")
 
         if request_id:
             if repo_id := request_id.get("repo_id"):

--- a/src/kospex_web.py
+++ b/src/kospex_web.py
@@ -3,6 +3,18 @@ import os
 import kospex_utils as KospexUtils
 from kospex.extractors.registry import classify
 
+# Friendly labels for the classify() kinds shown in the /osi/ commentary.
+_KIND_LABELS = {
+    "package": "Package manifests",
+    "runtime": "Runtime versions",
+    "container": "Container images",
+    "unknown": "Unrecognised files",
+    "sca_config": "SCA config",
+    "lockfile": "Lockfiles",
+}
+# Kinds recognised but not a package source kospex scans (so not "awaiting a parser").
+_NOT_A_SOURCE_KINDS = {"sca_config", "lockfile"}
+
 
 def get_id_params(request_id,request_params=None):
     """
@@ -54,12 +66,18 @@ def osi_extraction_view(files, extracted_keys):
     extracted_keys: set of (repo_id, file_path) that have extracted dependency rows.
 
     Sets file["extracted"] = True/False on each file. Returns (files, commentary)
-    where commentary = {"no_parser": {kind_value: {basename: count}}, "not_scanned": int}:
-      - no_parser: not-extracted files whose type has no parser (classify.supported False),
-        grouped by kind then basename.
+    where commentary now has three keys:
+      no_parser {label: {basename: count}} for parser-planned kinds,
+      not_a_source {label: {basename: count}} for sca_config/lockfile,
+      not_scanned int:
+      - no_parser: not-extracted files whose type has no parser (classify.supported False)
+        and is genuinely awaiting a parser, grouped by friendly label then basename.
+      - not_a_source: not-extracted files whose type is recognised but not a package
+        source kospex scans (sca_config/lockfile), grouped by friendly label then basename.
       - not_scanned: count of not-extracted files whose type IS supported (just not scanned).
     """
     no_parser = {}
+    not_a_source = {}
     not_scanned = 0
 
     for f in files:
@@ -72,10 +90,14 @@ def osi_extraction_view(files, extracted_keys):
         result = classify(f.get("Provider") or "")
         if result.supported:
             not_scanned += 1
-        else:
-            basename = os.path.basename(f.get("Provider") or "")
-            kind = result.kind.value
-            no_parser.setdefault(kind, {})
-            no_parser[kind][basename] = no_parser[kind].get(basename, 0) + 1
+            continue
 
-    return files, {"no_parser": no_parser, "not_scanned": not_scanned}
+        basename = os.path.basename(f.get("Provider") or "")
+        kind = result.kind.value
+        label = _KIND_LABELS.get(kind, kind)
+        bucket = not_a_source if kind in _NOT_A_SOURCE_KINDS else no_parser
+        bucket.setdefault(label, {})
+        bucket[label][basename] = bucket[label].get(basename, 0) + 1
+
+    return files, {"no_parser": no_parser, "not_a_source": not_a_source,
+                   "not_scanned": not_scanned}

--- a/src/kospex_web.py
+++ b/src/kospex_web.py
@@ -1,5 +1,7 @@
 """ Helper functions for kospex web UI """
+import os
 import kospex_utils as KospexUtils
+from kospex.extractors.registry import classify
 
 
 def get_id_params(request_id,request_params=None):
@@ -42,3 +44,38 @@ def get_id_params(request_id,request_params=None):
         params["server"] = request_id
 
     return params
+
+
+def osi_extraction_view(files, extracted_keys):
+    """Annotate /osi/ dependency files with realized extraction status and build
+    the commentary buckets.
+
+    files: list of file_metadata dicts (each with _repo_id and Provider).
+    extracted_keys: set of (repo_id, file_path) that have extracted dependency rows.
+
+    Sets file["extracted"] = True/False on each file. Returns (files, commentary)
+    where commentary = {"no_parser": {kind_value: {basename: count}}, "not_scanned": int}:
+      - no_parser: not-extracted files whose type has no parser (classify.supported False),
+        grouped by kind then basename.
+      - not_scanned: count of not-extracted files whose type IS supported (just not scanned).
+    """
+    no_parser = {}
+    not_scanned = 0
+
+    for f in files:
+        key = (f.get("_repo_id"), f.get("Provider"))
+        extracted = key in extracted_keys
+        f["extracted"] = extracted
+        if extracted:
+            continue
+
+        result = classify(f.get("Provider") or "")
+        if result.supported:
+            not_scanned += 1
+        else:
+            basename = os.path.basename(f.get("Provider") or "")
+            kind = result.kind.value
+            no_parser.setdefault(kind, {})
+            no_parser[kind][basename] = no_parser[kind].get(basename, 0) + 1
+
+    return files, {"no_parser": no_parser, "not_scanned": not_scanned}

--- a/src/kweb2.py
+++ b/src/kweb2.py
@@ -487,6 +487,9 @@ async def osi(request: Request, id: Optional[str] = None):
             file["days_ago"] = KospexUtils.days_ago(file.get("committer_when"))
             file["status"] = KospexUtils.development_status(file.get("days_ago"))
 
+        extracted_keys = KospexQuery().extracted_dependency_file_keys(request_id=params)
+        deps, commentary = KospexWeb.osi_extraction_view(deps, extracted_keys)
+
         file_number = len(deps)
         status = KospexUtils.repo_stats(deps, "committer_when")
         filenames = KospexUtils.filenames_by_repo_id(deps)
@@ -498,6 +501,7 @@ async def osi(request: Request, id: Optional[str] = None):
                 "file_number": file_number,
                 "dep_files": filenames,
                 "status": status,
+                "commentary": commentary,
             },
         )
     except Exception as e:

--- a/src/templates/osi.html
+++ b/src/templates/osi.html
@@ -31,6 +31,35 @@
 
         <!-- Main content area -->
         <div class="container mx-auto px-4 mt-12">
+            <!-- Dependency Extraction Coverage -->
+            <div class="bg-white border border-gray-200 rounded-lg shadow-sm mb-8">
+                <div class="p-6">
+                    <h2 class="text-2xl font-bold text-gray-900 mb-4">
+                        Dependency extraction coverage
+                    </h2>
+                    {% if commentary and (commentary['no_parser'] or commentary['not_scanned']) %}
+                        {% if commentary['no_parser'] %}
+                        <p class="text-gray-700 mb-2">Not extracted — no parser yet:</p>
+                        <ul class="list-disc list-inside text-gray-700 mb-3">
+                            {% for kind, types in commentary['no_parser'].items() %}
+                            <li>
+                                <span class="font-semibold">{{ kind }}</span>:
+                                {% for name, count in types.items() %}{{ name }} ({{ count }}){% if not loop.last %}, {% endif %}{% endfor %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                        {% if commentary['not_scanned'] %}
+                        <p class="text-gray-700">
+                            {{ commentary['not_scanned'] }} supported file{{ 's' if commentary['not_scanned'] != 1 else '' }} not yet scanned — run <code>kospex sca</code> / <code>krunner osi</code> to extract them.
+                        </p>
+                        {% endif %}
+                    {% else %}
+                        <p class="text-gray-700">All discovered dependency files have extracted details.</p>
+                    {% endif %}
+                </div>
+            </div>
+
             <!-- Page Header -->
             <div
                 class="bg-white border border-gray-200 rounded-lg shadow-sm mb-8"
@@ -225,6 +254,11 @@
                                     >
                                         Days Ago
                                     </th>
+                                    <th
+                                        class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                                    >
+                                        Extracted?
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody class="bg-white divide-y divide-gray-200">
@@ -259,11 +293,23 @@
                                     >
                                         {{ row.get('days_ago',"-") }}
                                     </td>
+                                    <td
+                                        class="px-6 py-4 whitespace-nowrap text-sm text-center"
+                                    >
+                                        {% if row.get('extracted') %}
+                                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">Yes</span>
+                                        {% else %}
+                                        <span class="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-700">No</span>
+                                        {% endif %}
+                                    </td>
                                 </tr>
                                 {% endfor %}
                             </tbody>
                         </table>
                     </div>
+                    <p class="text-sm text-gray-500 mt-3">
+                        "Extracted?" = kospex has parsed and enriched dependency details from this file.
+                    </p>
                 </div>
             </div>
         </div>

--- a/src/templates/osi.html
+++ b/src/templates/osi.html
@@ -37,13 +37,24 @@
                     <h2 class="text-2xl font-bold text-gray-900 mb-4">
                         Dependency extraction coverage
                     </h2>
-                    {% if commentary and (commentary['no_parser'] or commentary['not_scanned']) %}
+                    {% if commentary and (commentary['no_parser'] or commentary['not_a_source'] or commentary['not_scanned']) %}
                         {% if commentary['no_parser'] %}
                         <p class="text-gray-700 mb-2">Not extracted — no parser yet:</p>
                         <ul class="list-disc list-inside text-gray-700 mb-3">
-                            {% for kind, types in commentary['no_parser'].items() %}
+                            {% for label, types in commentary['no_parser'].items() %}
                             <li>
-                                <span class="font-semibold">{{ kind }}</span>:
+                                <span class="font-semibold">{{ label }}</span>:
+                                {% for name, count in types.items() %}{{ name }} ({{ count }}){% if not loop.last %}, {% endif %}{% endfor %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                        {% if commentary['not_a_source'] %}
+                        <p class="text-gray-700 mb-2">Recognised, but not scanned for packages:</p>
+                        <ul class="list-disc list-inside text-gray-700 mb-3">
+                            {% for label, types in commentary['not_a_source'].items() %}
+                            <li>
+                                <span class="font-semibold">{{ label }}</span>:
                                 {% for name, count in types.items() %}{{ name }} ({{ count }}){% if not loop.last %}, {% endif %}{% endfor %}
                             </li>
                             {% endfor %}

--- a/tests/test_extracted_file_keys.py
+++ b/tests/test_extracted_file_keys.py
@@ -1,0 +1,41 @@
+"""Tests for KospexQuery.extracted_dependency_file_keys (sub-project B)."""
+import sqlite_utils
+import kospex_schema as KospexSchema
+from kospex_query import KospexQuery
+
+
+def _kq_with_rows(rows):
+    db = sqlite_utils.Database(memory=True)
+    db.execute(KospexSchema.SQL_CREATE_DEPENDENCY_DATA)
+    for r in rows:
+        db["dependency_data"].insert(r, pk=["_repo_id", "hash", "file_path",
+                                            "package_type", "package_name",
+                                            "package_version"], alter=True)
+    return KospexQuery(kospex_db=db)
+
+
+def test_returns_latest_repo_file_pairs():
+    kq = _kq_with_rows([
+        {"_repo_id": "s~o~r", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "a", "package_version": "1", "latest": 1},
+        {"_repo_id": "s~o~r", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "b", "package_version": "2", "latest": 1},
+        {"_repo_id": "s~o~r", "hash": "h2", "file_path": "package.json",
+         "package_type": "npm", "package_name": "c", "package_version": "3", "latest": 1},
+        {"_repo_id": "s~o~old", "hash": "h3", "file_path": "old.txt",
+         "package_type": "pypi", "package_name": "d", "package_version": "4", "latest": 0},
+    ])
+    keys = kq.extracted_dependency_file_keys()
+    assert keys == {("s~o~r", "requirements.txt"), ("s~o~r", "package.json")}
+    assert isinstance(keys, set)
+
+
+def test_scoped_by_repo_id():
+    kq = _kq_with_rows([
+        {"_repo_id": "s~o~r1", "hash": "h1", "file_path": "requirements.txt",
+         "package_type": "pypi", "package_name": "a", "package_version": "1", "latest": 1},
+        {"_repo_id": "s~o~r2", "hash": "h2", "file_path": "package.json",
+         "package_type": "npm", "package_name": "c", "package_version": "3", "latest": 1},
+    ])
+    keys = kq.extracted_dependency_file_keys({"repo_id": "s~o~r1"})
+    assert keys == {("s~o~r1", "requirements.txt")}

--- a/tests/test_osi_extraction_view.py
+++ b/tests/test_osi_extraction_view.py
@@ -9,11 +9,11 @@ def _f(repo, provider, filename=None):
 
 def test_marks_extracted_and_buckets_the_rest():
     files = [
-        _f("s~o~r", "requirements.txt"),              # extracted (supported)
-        _f("s~o~r", "package.json"),                  # NOT extracted, supported -> not_scanned
-        _f("s~o~r", "yarn.lock"),                     # NOT extracted, no parser -> no_parser[package]
-        _f("s~o~r", "sub/uv.lock", "uv.lock"),        # NOT extracted, no parser -> no_parser[package]
-        _f("s~o~r", ".github/Dockerfile", "Dockerfile"),  # NOT extracted -> no_parser[container]
+        _f("s~o~r", "requirements.txt"),                  # extracted (supported)
+        _f("s~o~r", "package.json"),                      # NOT extracted, supported -> not_scanned
+        _f("s~o~r", "yarn.lock"),                         # NOT extracted, no parser (package)
+        _f("s~o~r", "sub/uv.lock", "uv.lock"),            # NOT extracted, no parser (package)
+        _f("s~o~r", ".github/Dockerfile", "Dockerfile"),  # NOT extracted, no parser (container)
     ]
     extracted = {("s~o~r", "requirements.txt")}
 
@@ -24,9 +24,25 @@ def test_marks_extracted_and_buckets_the_rest():
     assert by_provider["package.json"] is False
     assert by_provider["yarn.lock"] is False
 
-    assert commentary["no_parser"]["package"] == {"yarn.lock": 1, "uv.lock": 1}
-    assert commentary["no_parser"]["container"] == {"Dockerfile": 1}
+    # friendly labels, parser-planned kinds under no_parser
+    assert commentary["no_parser"]["Package manifests"] == {"yarn.lock": 1, "uv.lock": 1}
+    assert commentary["no_parser"]["Container images"] == {"Dockerfile": 1}
+    assert commentary["not_a_source"] == {}
     assert commentary["not_scanned"] == 1  # the package.json
+
+
+def test_not_a_source_kinds_bucketed():
+    files = [
+        _f("s~o~r", ".github/dependabot.yml", "dependabot.yml"),  # sca_config
+        _f("s~o~r", "go.sum"),                                    # lockfile
+    ]
+    _out, commentary = KospexWeb.osi_extraction_view(files, set())
+    assert commentary["no_parser"] == {}
+    assert commentary["not_a_source"] == {
+        "SCA config": {"dependabot.yml": 1},
+        "Lockfiles": {"go.sum": 1},
+    }
+    assert commentary["not_scanned"] == 0
 
 
 def test_all_extracted_gives_empty_commentary():
@@ -34,4 +50,4 @@ def test_all_extracted_gives_empty_commentary():
     extracted = {("s~o~r", "requirements.txt"), ("s~o~r", "package.json")}
     out_files, commentary = KospexWeb.osi_extraction_view(files, extracted)
     assert all(f["extracted"] for f in out_files)
-    assert commentary == {"no_parser": {}, "not_scanned": 0}
+    assert commentary == {"no_parser": {}, "not_a_source": {}, "not_scanned": 0}

--- a/tests/test_osi_extraction_view.py
+++ b/tests/test_osi_extraction_view.py
@@ -1,0 +1,37 @@
+"""Tests for kospex_web.osi_extraction_view (sub-project B)."""
+import kospex_web as KospexWeb
+
+
+def _f(repo, provider, filename=None):
+    return {"_repo_id": repo, "Provider": provider,
+            "Filename": filename or provider.rsplit("/", 1)[-1]}
+
+
+def test_marks_extracted_and_buckets_the_rest():
+    files = [
+        _f("s~o~r", "requirements.txt"),              # extracted (supported)
+        _f("s~o~r", "package.json"),                  # NOT extracted, supported -> not_scanned
+        _f("s~o~r", "yarn.lock"),                     # NOT extracted, no parser -> no_parser[package]
+        _f("s~o~r", "sub/uv.lock", "uv.lock"),        # NOT extracted, no parser -> no_parser[package]
+        _f("s~o~r", ".github/Dockerfile", "Dockerfile"),  # NOT extracted -> no_parser[container]
+    ]
+    extracted = {("s~o~r", "requirements.txt")}
+
+    out_files, commentary = KospexWeb.osi_extraction_view(files, extracted)
+
+    by_provider = {f["Provider"]: f["extracted"] for f in out_files}
+    assert by_provider["requirements.txt"] is True
+    assert by_provider["package.json"] is False
+    assert by_provider["yarn.lock"] is False
+
+    assert commentary["no_parser"]["package"] == {"yarn.lock": 1, "uv.lock": 1}
+    assert commentary["no_parser"]["container"] == {"Dockerfile": 1}
+    assert commentary["not_scanned"] == 1  # the package.json
+
+
+def test_all_extracted_gives_empty_commentary():
+    files = [_f("s~o~r", "requirements.txt"), _f("s~o~r", "package.json")]
+    extracted = {("s~o~r", "requirements.txt"), ("s~o~r", "package.json")}
+    out_files, commentary = KospexWeb.osi_extraction_view(files, extracted)
+    assert all(f["extracted"] for f in out_files)
+    assert commentary == {"no_parser": {}, "not_scanned": 0}

--- a/tests/test_osi_template.py
+++ b/tests/test_osi_template.py
@@ -1,0 +1,31 @@
+"""Render tests for the /osi/ page (sub-project B)."""
+import kweb2
+
+
+def _render(context):
+    tmpl = kweb2.templates.get_template("osi.html")
+    base = {"request": None, "data": [], "file_number": 0,
+            "dep_files": [], "status": {}, "commentary": {"no_parser": {}, "not_scanned": 0}}
+    base.update(context)
+    return tmpl.render(base)
+
+
+def test_extracted_badges_and_commentary():
+    rows = [
+        {"_repo_id": "s~o~r", "_git_repo": "r", "Provider": "requirements.txt",
+         "committer_when": "2025-01-01", "status": "Active", "days_ago": 1, "extracted": True},
+        {"_repo_id": "s~o~r", "_git_repo": "r", "Provider": "yarn.lock",
+         "committer_when": "2025-01-01", "status": "Active", "days_ago": 1, "extracted": False},
+    ]
+    commentary = {"no_parser": {"package": {"yarn.lock": 49}, "container": {"Dockerfile": 3}},
+                  "not_scanned": 5}
+    html = _render({"data": rows, "file_number": 2, "commentary": commentary})
+    assert "Extracted?" in html          # new column header
+    assert "Yes" in html and "No" in html
+    assert "yarn.lock" in html and "49" in html   # commentary names the type + count
+    assert "not yet scanned" in html.lower()      # the not_scanned line
+
+
+def test_all_extracted_message():
+    html = _render({"commentary": {"no_parser": {}, "not_scanned": 0}})
+    assert "all discovered dependency files have extracted details" in html.lower()

--- a/tests/test_osi_template.py
+++ b/tests/test_osi_template.py
@@ -5,7 +5,8 @@ import kweb2
 def _render(context):
     tmpl = kweb2.templates.get_template("osi.html")
     base = {"request": None, "data": [], "file_number": 0,
-            "dep_files": [], "status": {}, "commentary": {"no_parser": {}, "not_scanned": 0}}
+            "dep_files": [], "status": {},
+            "commentary": {"no_parser": {}, "not_a_source": {}, "not_scanned": 0}}
     base.update(context)
     return tmpl.render(base)
 
@@ -17,15 +18,17 @@ def test_extracted_badges_and_commentary():
         {"_repo_id": "s~o~r", "_git_repo": "r", "Provider": "yarn.lock",
          "committer_when": "2025-01-01", "status": "Active", "days_ago": 1, "extracted": False},
     ]
-    commentary = {"no_parser": {"package": {"yarn.lock": 49}, "container": {"Dockerfile": 3}},
+    commentary = {"no_parser": {"Package manifests": {"yarn.lock": 49}},
+                  "not_a_source": {"SCA config": {"dependabot.yml": 40}},
                   "not_scanned": 5}
     html = _render({"data": rows, "file_number": 2, "commentary": commentary})
-    assert "Extracted?" in html          # new column header
+    assert "Extracted?" in html
     assert "Yes" in html and "No" in html
-    assert "yarn.lock" in html and "49" in html   # commentary names the type + count
-    assert "not yet scanned" in html.lower()      # the not_scanned line
+    assert "Package manifests" in html and "yarn.lock" in html and "49" in html
+    assert "Recognised, but not scanned for packages" in html and "SCA config" in html
+    assert "not yet scanned" in html.lower()
 
 
 def test_all_extracted_message():
-    html = _render({"commentary": {"no_parser": {}, "not_scanned": 0}})
+    html = _render({"commentary": {"no_parser": {}, "not_a_source": {}, "not_scanned": 0}})
     assert "all discovered dependency files have extracted details" in html.lower()


### PR DESCRIPTION
## Overview

Sub-project **B** of the extractor program: surface on `/osi/` whether kospex has actually **extracted** dependency details from each discovered file, plus an honest, grouped explanation of the gaps. Consumes the `classify()` registry merged in sub-project A (#114). Additive; no schema change.

Previously `/osi/` listed dependency files by freshness only — a `package.json` we parsed into 40 enriched dependencies looked identical to a `yarn.lock` we can't parse at all.

Design & plan: `changes/2026-07-20-osi-extraction-status-design.md` / `-plan.md`.

## What "Extracted?" means

**Realized, per file:** kospex has parsed dependencies out of *this* file (there are `latest=1` rows in `dependency_data` for its `(_repo_id, file_path)`). This is distinct from "supported" (a parser exists for the *type*) — a `package.json` can be a supported type yet un-extracted because its repo was never scanned. Only the realized signal is a column; capability (`classify().kind`/`supported`) drives the commentary only.

## What this adds

- **`KospexQuery.extracted_dependency_file_keys(request_id)`** — a scoped, SQL-deduplicated `set` of `(_repo_id, file_path)` with extracted rows.
- **`kospex_web.osi_extraction_view(files, extracted_keys)`** — a pure helper that marks each file `extracted` and builds the commentary buckets via `classify()`.
- **`/osi/` route + `osi.html`** — an **"Extracted?"** Yes/No column (appended last, so the DataTable sort is unaffected; Yes rows link through to `/dependencies/`), and a **"Dependency extraction coverage"** callout above the tables:
  - *Not extracted — no parser yet:* grouped by kind (Package manifests, Runtime versions, Container images) with counts.
  - *Recognised, but not scanned for packages:* SCA config (`dependabot.yml`), Lockfiles (`go.sum`) — honestly separated from "awaiting a parser."
  - *N supported files not yet scanned — run `kospex sca` / `krunner osi`.*
  - or *"All discovered dependency files have extracted details."*

The dev-status table, "N files found" line, and Dependency File Summary table are unchanged.

## Not in scope (deferred)

- **Staleness** — `/osi/` reflects the last `krunner osi` / `kospex sca`; it doesn't trigger extraction. The "not yet scanned" line surfaces this; auto-refresh is later.
- **C** (route scanners through the registry — closes the `go.mod`/nuget gap), **D** (new parsers: `package-lock.json`, `yarn.lock`), and the actions/`cicd` interface (N4–N6).

## Testing

Unit tests for the query (latest-filter, dedup, scope) and the pure helper (extracted flag, bucket routing, friendly labels), plus an in-process `osi.html` render test (badges, both callout headings, counts, all-extracted fallback). Full suite: **426 passed**. The query→helper seam was validated against a real DB (415/416 keys map exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
