### PR TITLE
fix(git): parse brace-less renames in parse_git_rename_event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,11 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   doubled slash (`.github//dependabot.yml`). That malformed `commit_files` path
   never matched the working-tree path, so `file_metadata.committer_when` was
   left NULL and surfaced as "last commit: None". Repeated slashes are now
-  collapsed after rename substitution; existing rows clear on the next
-  `kospex sync`. PR [#115](https://github.com/kospex/kospex/pull/115). (The
+  collapsed after rename substitution. PR
+  [#115](https://github.com/kospex/kospex/pull/115). Note: because `kospex sync`
+  is incremental, rows already stored with the bad path do **not** self-heal —
+  DBs synced before this fix can clear them with the one-off SQL in
+  `changes/2026-07-21-commit-files-double-slash-remediation.md`. (The
   non-ASCII-filename variant of the same NULL is tracked in
   [#116](https://github.com/kospex/kospex/issues/116).)
 - **`pypi_assess` no longer drops the version on multiple-specifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   that assumed the sentinel should treat `NULL` as "not resolved".
 
 ### Fixed
+- **Brace-less git renames are now parsed**. `git log --numstat` only uses the
+  brace form when the old and new paths share a common leading directory or
+  trailing component; with nothing in common it emits a bare `old => new` (e.g.
+  `LICENSE.rst => LICENSE.txt`, or a root-level file moved into a subdirectory).
+  `parse_git_rename_event` required braces, so the raw arrow string was stored
+  as `commit_files.file_path` — a second, independent source of the
+  `file_metadata.committer_when` NULL that surfaces as "last commit: None" on
+  `/osi/`. The new path is now kept for the brace-less form. Existing rows do
+  not self-heal (an incremental re-sync only reads commits newer than the last
+  synced one, so the old rename commit is never re-parsed); see
+  `changes/2026-07-21-rename-arrow-braceless-remediation.md` for the one-off SQL.
 - **`/osi/` "last commit" no longer shows `None` for renamed files**. A
   directory-level rename (a file moved up or down a level) renders in
   `git log --numstat` with an empty brace side (e.g.

--- a/changes/2026-07-21-commit-files-double-slash-remediation.md
+++ b/changes/2026-07-21-commit-files-double-slash-remediation.md
@@ -1,0 +1,93 @@
+# Remediation: clear `/osi/` "last commit: None" from pre-#115 double-slash paths
+
+## Who needs this
+
+Only kospex databases that were **synced before the #115 fix**. New installs
+are unaffected (the fixed `parse_git_rename_event` never produces the bad path),
+so this is deliberately **not** a migration — run it by hand only if your
+existing DB shows the symptom.
+
+**Symptom:** on `/osi/` (and anywhere per-file "last commit" / dev-status is
+shown) a file has a **last commit of `None`**. It happens for files that were
+**moved between directories** at some point (e.g. `.github/dependabot.yml` after
+it moved out of `.github/workflows/`).
+
+## Cause (recap)
+
+`git log --numstat` renders a directory-level rename with an empty brace side,
+e.g. `.github/{workflows => }/dependabot.yml`. Before #115,
+`parse_git_rename_event` collapsed that to a **doubled slash**
+(`.github//dependabot.yml`) and stored it in `commit_files`. That malformed path
+never matches the real working-tree path, so `file_metadata.committer_when` is
+left `NULL`. #115 fixed the parser going forward, but **an incremental
+`kospex sync` never re-parses the old rename commit**, so already-stored rows do
+not self-heal — they must be corrected directly.
+
+## The fix
+
+**Back up your database first:**
+
+```bash
+cp ~/kospex/kospex.db ~/kospex/kospex.db.bak-$(date +%Y%m%d-%H%M%S)
+```
+
+Then, against `~/kospex/kospex.db`:
+
+```sql
+-- Step 1: collapse the doubled slash in stored commit paths (matches what the
+-- #115-fixed parser now produces). Repo-relative git paths never legitimately
+-- contain '//', and there are no 3+-slash cases, so a single REPLACE is safe.
+UPDATE commit_files
+SET file_path = REPLACE(file_path, '//', '/')
+WHERE file_path LIKE '%//%';
+
+-- Step 2: backfill committer_when for the file_metadata rows that now match a
+-- corrected commit path. Bounded to the currently-NULL rows, so it is cheap.
+UPDATE file_metadata
+SET committer_when = (
+    SELECT cf.committer_when FROM commit_files cf
+    WHERE cf._repo_id = file_metadata._repo_id
+      AND cf.file_path = file_metadata.Provider
+    ORDER BY cf.committer_when DESC LIMIT 1)
+WHERE committer_when IS NULL
+  AND EXISTS (
+    SELECT 1 FROM commit_files cf
+    WHERE cf._repo_id = file_metadata._repo_id
+      AND cf.file_path = file_metadata.Provider);
+```
+
+Run it, e.g.:
+
+```bash
+sqlite3 ~/kospex/kospex.db < fix.sql      # or paste the two statements interactively
+```
+
+## Verify
+
+```sql
+-- Was ~N NULL rows; should drop by the double-slash count after the fix.
+SELECT COUNT(*) FROM file_metadata WHERE latest = 1 AND committer_when IS NULL;
+
+-- Spot-check the file you noticed (adjust repo_id / Provider):
+SELECT committer_when FROM file_metadata
+WHERE latest = 1
+  AND _repo_id = 'github.com~expressjs~express'
+  AND Provider = '.github/dependabot.yml';
+-- expect a real date, not NULL
+```
+
+## Scope & notes
+
+- This fixes only the **double-slash** cause. `NULL` `committer_when` from
+  **non-ASCII filenames** (git quotes them in `--numstat` output) is a separate
+  cause tracked in **issue #116** and is *not* addressed here.
+- Step 2 only restores `committer_when` (the visible "last commit" value). It
+  leaves `file_metadata.hash` at its previous fallback (repo HEAD). If you want
+  `file_metadata` fully regenerated (both `hash` and `committer_when`) from the
+  corrected `commit_files`, run `kospex sync-metadata -repo <repo_dir> -force`
+  for each affected repo instead of Step 2 — slower (re-scans the working tree),
+  but canonical.
+- **Large DBs:** Step 1's `WHERE file_path LIKE '%//%'` scans `commit_files`
+  (no index on the path), so on a very large history it can take a while. It is
+  a one-time operation; run it when convenient.
+- Related: #115 (the forward fix), #116 (the unicode variant).

--- a/changes/2026-07-21-rename-arrow-braceless-remediation.md
+++ b/changes/2026-07-21-rename-arrow-braceless-remediation.md
@@ -1,0 +1,106 @@
+# Brace-less git rename paths stored raw in `commit_files`
+
+## Symptom
+
+Same visible symptom as the double-slash bug (`2026-07-21-commit-files-double-slash-remediation.md`):
+a file shows **last commit `None`** on `/osi/` and anywhere per-file "last commit" /
+dev-status is rendered. Different cause, so the earlier remediation does not fix these.
+
+## Cause
+
+`git log --numstat` compresses a rename using braces **only when the old and new
+paths share a common leading directory or trailing component**:
+
+```
+docs/{license.rst => license.md}          # shared prefix "docs/"
+.github/{workflows => }/dependabot.yml    # shared prefix and suffix
+```
+
+When the two paths have **nothing** in common, git emits the whole field as a
+bare `old => new` with no braces:
+
+```
+FASTAPI_MIGRATION.md => changes/FASTAPI_MIGRATION.md   # root file moved into a subdir
+LICENSE.rst => LICENSE.txt                             # extension change at the root
+```
+
+`extract_git_rename_paths()` matches on `r'{[^{]* => [^}]*}'` — braces are
+mandatory — so `parse_git_rename_event()` returned the brace-less form
+**unchanged**. The literal string `"LICENSE.rst => LICENSE.txt"` was then stored
+as `commit_files.file_path`, never matched the working-tree path, and
+`build_file_metadata_rows` left `file_metadata.committer_when` NULL.
+
+Fixed in `parse_git_rename_event()`: when no brace rename matched but the field
+still contains `" => "`, keep the right-hand (new) path. Guarded on the spaced
+`" => "` so a filename that merely contains `=>` is untouched. Test:
+`tests/test_kospex.py::test_git_rename_event_no_braces`.
+
+## Remediation for existing databases
+
+New syncs are correct from this fix onward, but **an incremental re-sync
+(`kgit pull`, `kgit sync`, `kospex sync-directory`) only reads commits newer than
+the last synced one**, so it never re-parses the old rename commit and stored
+rows do not self-heal. This is deliberately **not** a migration — run it only if
+your DB predates the fix.
+
+**Back up first:**
+
+```bash
+cp ~/kospex/kospex.db ~/kospex/kospex.db.bak-$(date +%Y%m%d-%H%M%S)
+```
+
+Optional pre-check — should return 0. If it does not, collapsing the arrow would
+collide with an existing `(hash, file_path, _repo_id)` primary key, and Step 1
+will fail rather than silently drop a row:
+
+```sql
+SELECT COUNT(*) FROM commit_files a
+JOIN commit_files b
+  ON a._repo_id = b._repo_id AND a.hash = b.hash
+ AND b.file_path = substr(a.file_path, instr(a.file_path, ' => ') + 4)
+WHERE a.file_path LIKE '% => %';
+```
+
+```sql
+-- Step 1: keep the new path from the raw "old => new" field, matching what the
+-- fixed parser now produces. ' => ' is 4 characters, so +4 starts the new path.
+UPDATE commit_files
+SET file_path = substr(file_path, instr(file_path, ' => ') + 4)
+WHERE file_path LIKE '% => %';
+
+-- Step 2: backfill committer_when for file_metadata rows that now match a
+-- corrected commit path. Bounded to currently-NULL rows, so it is cheap.
+UPDATE file_metadata
+SET committer_when = (
+    SELECT cf.committer_when FROM commit_files cf
+    WHERE cf._repo_id = file_metadata._repo_id
+      AND cf.file_path = file_metadata.Provider
+    ORDER BY cf.committer_when DESC LIMIT 1)
+WHERE committer_when IS NULL
+  AND EXISTS (
+    SELECT 1 FROM commit_files cf
+    WHERE cf._repo_id = file_metadata._repo_id
+      AND cf.file_path = file_metadata.Provider);
+```
+
+## Verify
+
+```sql
+SELECT COUNT(*) FROM commit_files WHERE file_path LIKE '% => %';        -- expect 0
+SELECT COUNT(*) FROM file_metadata WHERE latest = 1 AND committer_when IS NULL;
+```
+
+## Scope & notes
+
+- Step 2 restores `committer_when` only; `file_metadata.hash` keeps its previous
+  fallback (repo HEAD). For a canonical rebuild of both, run
+  `kospex sync-metadata -repo <repo_dir> -force` per affected repo instead.
+- Step 1's `LIKE '% => %'` scans `commit_files` (no index on the path); on a large
+  history it takes a while. One-time operation.
+- **Other known causes of a NULL `committer_when`**, not addressed here:
+  - non-ASCII filenames quoted by git `core.quotePath` — issue #116;
+  - files whose content was introduced **only by a merge commit** (subtree adds,
+    conflict-resolution edits). `git log --numstat` emits no diff for merge
+    commits by default, so no `commit_files` row exists at all, while
+    `file_metadata` still sees the file in the working tree.
+- Related: #115 (double-slash rename), #116 (unicode quoting).

--- a/changes/202607-sqlite-wal-busy-timeout.md
+++ b/changes/202607-sqlite-wal-busy-timeout.md
@@ -2,6 +2,7 @@
 
 **Status:** spec / not yet implemented
 **Date:** 2026-07
+**Tracked in:** kospex/kospex#119
 
 ## Problem
 

--- a/changes/202607-sqlite-wal-busy-timeout.md
+++ b/changes/202607-sqlite-wal-busy-timeout.md
@@ -1,0 +1,114 @@
+# SQLite WAL + busy_timeout on connect
+
+**Status:** spec / not yet implemented
+**Date:** 2026-07
+
+## Problem
+
+A user ingesting ~3000 repositories with multiple concurrent threads hits
+"database is locked" (`SQLITE_BUSY`) errors. SQLite is fundamentally
+single-writer: only one write transaction at a time, regardless of pragmas.
+Two low-risk mitigations reduce the pain today:
+
+- **`journal_mode=WAL`** — lets many readers run concurrently with the single
+  writer (readers no longer block the writer or vice-versa). It does **not**
+  allow multiple writers, but it removes reader/writer collisions, which is the
+  bulk of the contention for kospex's read-heavy web/report layer running
+  alongside ingest.
+- **`busy_timeout`** — turns most `SQLITE_BUSY` *errors* into short *waits*, so
+  concurrent writers queue on the lock instead of failing immediately.
+
+Currently neither is set. `grep` for `journal_mode`/`WAL`/`busy_timeout` across
+`src/` returns nothing, so the DB runs in default rollback-journal mode. There
+is no central connection factory — `Database(...)` is opened ad-hoc.
+
+> Note: this is the cheap, first-line fix. The larger wins (batching the
+> per-row `upsert()` loop in `kospex_core.py` into `upsert_all` transactions,
+> and an optional stage-to-disk + single-writer ingest architecture) are
+> separate follow-ups and out of scope here.
+
+## Design
+
+### Pragma lifetimes (why placement matters)
+
+| Pragma | Persistence | Consequence |
+|--------|-------------|-------------|
+| `journal_mode=WAL` | Persistent — written to the DB file header, survives across connections | Set once and it sticks; re-asserting when already WAL is a cheap no-op (no lock, no file I/O) |
+| `busy_timeout` | Per-connection — resets on every new connection | **Must** be applied on every connect |
+
+Because `busy_timeout` has to run on every connection anyway, a connection
+helper is required regardless. WAL rides along for free (idempotent).
+
+**WAL cannot be set in a migration.** `PRAGMA journal_mode=WAL` cannot run
+inside a transaction, and the migrator (`kospex/db/migrator.py`) wraps every
+migration — SQL and Python `up()` — in `BEGIN … COMMIT`. So migrations are the
+wrong vehicle; do not add it there.
+
+### 1. Connection helper (source of truth)
+
+Add a helper (proposed: `KospexUtils.get_kospex_db()` in `kospex_utils.py`,
+alongside `get_kospex_db_path()`):
+
+```python
+def get_kospex_db():
+    """Open the kospex SQLite DB with WAL + busy_timeout applied."""
+    from sqlite_utils import Database
+    db = Database(get_kospex_db_path())
+    db.conn.execute("PRAGMA journal_mode=WAL")   # persistent; no-op if already WAL
+    db.conn.execute("PRAGMA busy_timeout=5000")  # per-connection; must re-apply
+    return db
+```
+
+Route existing physical-DB call sites through it:
+
+- `kospex_query.py:27` — `Database(KospexUtils.get_kospex_db_path())`
+- `kospex_schema.py:452` — inside `connect_or_create_kospex_db()` (see below)
+- `repo_sync.py:194`, `repo_sync.py:284`
+
+Leave `Database(memory=True)` call sites alone (WAL is N/A for in-memory DBs).
+
+This helper is what actually converts the existing 3000-repo deployment: the
+first kospex process to connect flips its delete-mode DB to WAL. It is also
+self-healing — a restored backup or copied DB re-asserts WAL on next connect.
+
+### 2. Assert WAL at DB creation (kospex init)
+
+In `connect_or_create_kospex_db()` (`kospex_schema.py:449`, already tracks a
+`new_db` flag), and hence `kospex init --create`, set WAL immediately after
+opening/creating the DB — either by routing through `get_kospex_db()` or by
+adding the two pragmas inline.
+
+Benefit: a freshly created DB is canonically WAL before any table creation or
+ingest touches it, and the one-time `delete→wal` transition (which needs a
+brief exclusive lock) happens at the quietest possible moment. Steady-state
+connections then see WAL already set and do the cheap no-op.
+
+## Non-goals
+
+- No migration file for WAL (can't run in a transaction — see above).
+- Not batching the `upsert()` loop — separate change.
+- Not the stage-to-disk / single-writer ingest redesign — separate change.
+
+## Gotchas
+
+- First `delete→wal` transition needs a momentary exclusive lock; fine at init,
+  and fine on first connect since the flipping connection is the first to open.
+- WAL adds `-wal` and `-shm` sidecar files; the `-wal` grows until checkpoint.
+  For bulk ingest the defaults are fine — monitor WAL size under heavy write
+  load, don't tune preemptively.
+- Keep WAL consistent across all connections. Switching *out* of WAL requires
+  all connections closed; mixing journal modes across connections causes churn.
+
+## Verification
+
+- `sqlite3 ~/kospex/kospex.db "PRAGMA journal_mode;"` → `wal` after a connect or
+  after `kospex init --create`.
+- Confirm `-wal`/`-shm` files appear next to `kospex.db` during a sync.
+- Run a concurrent multi-thread ingest and confirm `SQLITE_BUSY` errors drop
+  (they should wait up to `busy_timeout` instead of erroring).
+
+## Files
+
+- `src/kospex_utils.py` — new `get_kospex_db()` helper.
+- `src/kospex_schema.py` — `connect_or_create_kospex_db()` sets WAL at creation.
+- `src/kospex_query.py`, `src/repo_sync.py` — route through the helper.

--- a/src/kospex_utils.py
+++ b/src/kospex_utils.py
@@ -635,6 +635,14 @@ def parse_git_rename_event(event_str):
         # leading-slash paths) are returned untouched.
         event_str = re.sub(r"/{2,}", "/", event_str).lstrip("/")
 
+    elif " => " in event_str:
+        # git only uses the brace form when the old and new paths share a
+        # common leading directory or trailing component. With nothing in
+        # common (a root-level file moved into a subdirectory, or an extension
+        # change) the whole field is a bare "old => new" — keep the new path,
+        # which is the one that exists in the working tree.
+        event_str = event_str.split(" => ", 1)[1]
+
     return event_str
 
 #def parse_git_rename_event(event_str):

--- a/tests/test_kospex.py
+++ b/tests/test_kospex.py
@@ -74,6 +74,23 @@ def test_git_rename_event_empty_brace_side():
     # Both-sides-present renames are unaffected
     assert KospexUtils.parse_git_rename_event("pkg/{old => new}/x.py") == "pkg/new/x.py"
 
+def test_git_rename_event_no_braces():
+    """git only uses the brace form when the old and new paths share a common
+    leading directory or trailing component. With nothing in common it emits a
+    bare "old => new", which must resolve to the new path — otherwise the raw
+    arrow string is stored as commit_files.file_path, never matches the
+    working-tree path, and file_metadata.committer_when ends up NULL."""
+    # Root-level file moved into a subdirectory (no shared prefix or suffix)
+    assert KospexUtils.parse_git_rename_event(
+        "FASTAPI_MIGRATION.md => changes/FASTAPI_MIGRATION.md") == "changes/FASTAPI_MIGRATION.md"
+    # Extension change at the repo root
+    assert KospexUtils.parse_git_rename_event("LICENSE.rst => LICENSE.txt") == "LICENSE.txt"
+    # Directory-to-directory move with nothing in common
+    assert KospexUtils.parse_git_rename_event("old/a.py => new/b.py") == "new/b.py"
+    # A path that merely contains "=>" without the git rename spacing is untouched
+    assert KospexUtils.parse_git_rename_event("src/a=>b.txt") == "src/a=>b.txt"
+
+
 def test_days_functions():
     """ Test the days calculation functions """
 


### PR DESCRIPTION
## Problem

`git log --numstat` only uses the brace form for a rename when the old and new
paths share a common leading directory or trailing component:

```
docs/{license.rst => license.md}          # shared prefix
.github/{workflows => }/dependabot.yml    # shared prefix + suffix  (fixed in #115)
```

With **nothing** in common, git emits a bare `old => new` with no braces:

```
FASTAPI_MIGRATION.md => changes/FASTAPI_MIGRATION.md   # root file moved into a subdir
LICENSE.rst => LICENSE.txt                             # extension change at the root
```

`extract_git_rename_paths()` matches `r'{[^{]* => [^}]*}'` — braces mandatory —
so `parse_git_rename_event()` returned these **unchanged**. The literal string
`"LICENSE.rst => LICENSE.txt"` was stored as `commit_files.file_path`, never
matched the working-tree path, and `build_file_metadata_rows` left
`file_metadata.committer_when` NULL — surfacing as "last commit: None" on `/osi/`.

Same visible symptom as #115 (double slash) and #116 (unicode quoting), but an
independent cause. Found while remediating the #115 NULLs: 702 rows across 70
repos in a real database carried an unparsed ` => `, and **zero** of them
contained braces.

## Fix

When no brace rename matched but the field still contains `" => "`, keep the
right-hand (new) path. Guarded on the spaced `" => "`, so a filename that merely
contains `=>` (`src/a=>b.txt`) is untouched.

## Tests

`tests/test_kospex.py::test_git_rename_event_no_braces` — written first and
watched fail, covering: root file moved into a subdirectory, extension change at
the root, directory-to-directory move with nothing in common, and the
`=>`-without-spaces non-rename case. Full suite: 427 passed.

## Existing databases

Rows already stored do not self-heal — an incremental re-sync only reads commits
newer than the last synced one, so the old rename commit is never re-parsed.
Deliberately **not** shipped as a migration (new installs are unaffected); the
one-off SQL is documented in
`changes/2026-07-21-rename-arrow-braceless-remediation.md`, alongside a PK-collision
pre-check. Verified against a real DB: 702 rows corrected, 78 `file_metadata`
rows backfilled, NULL `committer_when` down 276 → 234, `integrity_check` ok.

## Related

Two further causes of the same NULL were identified while investigating and are
filed separately, not addressed here:

- #120 — `days_ago(None)` returns `0.0`, so a missing date renders as `Active` /
  0 days ago and sorts to the top of `/osi/`
- #121 — `git log --numstat` emits no diff for merge commits, so content
  introduced only by a merge (subtree adds, conflict resolutions) has no
  `commit_files` row at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)