### PR TITLE
docs: broaden site positioning and fix prose/code CSS

### DIFF
--- a/changes/202607-docs-site-content-and-formatting.md
+++ b/changes/202607-docs-site-content-and-formatting.md
@@ -1,0 +1,132 @@
+# Docs site content and formatting overhaul
+
+Rework of the `docs/` Jekyll site published to [docs.kospex.io](https://docs.kospex.io):
+broader product positioning on the landing page, an accurate Web UI guide, and a fix for
+the CSS that was silently stripping spacing from every page.
+
+## Overview
+
+Three related problems:
+
+1. **Positioning was too narrow.** The landing page described kospex as a CLI that "looks
+   at the guts of your code". That undersells it and omits the Web UI entirely.
+2. **The Web UI docs were largely aspirational** — 14 "*(to be created)*" stub links, a
+   nav menu that didn't match the app, and several capabilities documented that don't exist.
+3. **Page formatting was broken sitewide** by missing CSS rules, not by the markdown.
+
+## Files changed
+
+| File | Change |
+| ---- | ------ |
+| `docs/index.md` | Repositioned around knowledge mapping, technology identification, open source libraries and maintenance indicators; CLI + Web UI both surfaced |
+| `docs/assets/css/style.css` | Restored prose typography, code block styling, syntax highlighting; fixed fixed-header overlap |
+| `docs/getting-started.md` | Heading hierarchy, consistent code fences, removed hard-break hacks |
+| `docs/kweb/index.md` | Rewritten against actual `kweb2.py` routes; removed unimplemented claims |
+
+## The CSS root cause
+
+`docs/assets/css/style.css` **replaces** the slate remote theme's stylesheet rather than
+extending it (Jekyll resolves a site file at that path ahead of the theme's). The theme's
+prose typography and Rouge syntax highlighting were therefore never loaded.
+
+Combined with the global `* { margin: 0; padding: 0; }` reset at the top of the file, this
+meant markdown-rendered content had no spacing rules at all:
+
+- **No `p` rule anywhere** — every paragraph rendered with zero margin, running together.
+  This is why `getting-started.md` had accumulated trailing-backslash hard-break hacks:
+  they were compensating for invisible paragraph breaks.
+- **No `h3` / `h4` rules** — sub-headings collided with the text above them.
+- **No `pre` / `code` rules** — fenced code blocks rendered as unstyled monospace with no
+  background, padding or horizontal scroll.
+- **Padding bug** — `padding-top: 100px` was immediately overridden by the
+  `padding: var(--section-padding)` shorthand on the following line, leaving 80px. The
+  header is `position: fixed` and stacks vertically below 768px, so content slid underneath
+  it on mobile.
+
+Fixes added under the "Markdown prose typography" block, plus a minimal Rouge palette for
+the shell/python/yaml snippets used across the docs.
+
+## Web UI doc corrections
+
+Claims removed because they are not implemented in `src/kweb2.py` or the templates:
+
+- CSV / JSON export and "custom report generation" — no export controls exist
+- "REST API … rate limiting and authentication support" — there is **no authentication**
+- "Community forums and discussion groups"
+- 14 placeholder links to per-view pages that were never written
+
+Corrections made:
+
+- Nav menu documented as it actually is: Summary, Repos, Orgs, Developers, **Opensource**,
+  Landscape, Metadata, Help (Summary and Opensource were both missing)
+- View paths grounded in real routes (`/osi/`, `/hotspots/{repo_id}`,
+  `/key-person/{repo_id}`, `/package-check/`, `/tenure/`, …)
+- Added a security callout: `kweb` binds to `127.0.0.1`, has no authentication, and should
+  not be exposed without something in front of it
+
+The Developers view previously listed "performance reviews" as a use case. Replaced with
+knowledge-mapping and offboarding framing, plus an explicit note that commit activity
+indicates where knowledge sits and is not a productivity metric.
+
+## Local preview environment
+
+`docs/Gemfile` pins `github-pages ~> 231`, which requires `commonmarker ~> 0.23.7`. That
+gemspec declares `required_ruby_version >= 2.6, < 4.0`. Homebrew's default `ruby` formula
+has rolled to **4.0.x**, so `bundle install` fails to resolve:
+
+```
+Because github-pages >= 228, < 232 depends on jekyll-commonmark-ghpages = 0.4.0
+  and jekyll-commonmark-ghpages >= 0.4.0, < 0.5.0 depends on commonmarker ~> 0.23.7 ...
+So, because Gemfile depends on github-pages ~> 231
+  and current Ruby version is = 4.0.3,
+  version solving has failed.
+```
+
+Worth recording: `gh api repos/kospex/kospex/pages` reports `"build_type": "legacy"` with
+source `main` at `/docs`. Despite the name, "legacy" is just the API's label for
+"Deploy from a branch" — it is **not deprecated**, and GitHub still recommends it for sites
+that don't need build customisation. The site is built by GitHub's classic server-side
+build, so **the Gemfile does not affect what is published** — it only governs local
+preview. (`docs/Gemfile` and `docs/Gemfile.lock` are gitignored for this reason.)
+
+Per [pages.github.com/versions](https://pages.github.com/versions/), GitHub Pages currently
+runs **Ruby 3.3.4**, Jekyll 3.10.0, github-pages 232.
+
+Resolution:
+
+```bash
+brew install ruby@3.3          # keg-only; system ruby 4.x untouched
+
+cd docs
+export PATH="/opt/homebrew/opt/ruby@3.3/bin:$PATH"
+bundle install
+bundle exec jekyll serve
+```
+
+The local `Gemfile` pin was also bumped from `~> 231` to `~> 232` to match the version
+GitHub actually builds with.
+
+Longer term the intent is to move docs to Cloudflare Pages, matching the main kospex.io
+site, rather than migrating to a GitHub Actions Pages workflow.
+
+## Verification
+
+Site builds clean under Ruby 3.3.12 (`done in 1.539 seconds`). Rendered output checked via
+headless Chrome:
+
+- Paragraph spacing, heading hierarchy, inline code and fenced code blocks all render
+  correctly at desktop and tablet widths
+- Rouge syntax highlighting is applied (`.highlight .c`, `.highlight .nb` present in output)
+- `document.documentElement.scrollWidth == viewport` — no horizontal page overflow
+- Long command lines scroll inside their `pre` (measured 616px content inside a constrained
+  block) rather than widening the page
+
+## Not done
+
+- **True phone-width rendering (<500px) is unverified.** Headless Chrome on macOS clamps the
+  window to a 500px minimum and crops the screenshot to the requested size, which makes
+  narrow-viewport screenshots misleading. Verifying below 500px needs DevTools device
+  emulation. The mobile `padding-top: 200px` header clearance was checked at 500px, not at
+  375–390px.
+- Per-view Web UI pages (repos, developers, landscape, …) remain unwritten. The stub links
+  were removed rather than left as dead placeholders.

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -586,10 +586,109 @@ tr:nth-child(even) {
 }
 
 #main_content {
-    padding-top: 100px; /* Adjust based on your header height */
+    /* Top padding must clear the fixed header, which is ~76px tall on desktop.
+       Note: this must be a single shorthand — an earlier `padding-top` followed
+       by a `padding` shorthand gets silently overridden. */
+    padding: 120px 0 60px;
     margin-bottom: 50px; /* Add some space before footer */
-    padding: var(--section-padding);
 }
+
+/* The mobile navbar stacks vertically and is much taller, so content needs
+   more clearance or it slides under the fixed header. */
+@media (max-width: 768px) {
+    #main_content {
+        padding-top: 200px;
+    }
+}
+
+/* Markdown prose typography.
+   The global `* { margin: 0 }` reset above strips spacing from every element,
+   so anything rendered from markdown needs its spacing restored explicitly. */
+#main_content p {
+    margin-bottom: 1.1em;
+}
+
+#main_content h3 {
+    margin-top: 1.6em;
+    margin-bottom: 0.6em;
+    color: var(--primary-color);
+    font-size: 1.35em;
+}
+
+#main_content h4 {
+    margin-top: 1.4em;
+    margin-bottom: 0.5em;
+    color: var(--primary-color);
+    font-size: 1.1em;
+}
+
+#main_content hr {
+    border: none;
+    border-top: 1px solid #e1e4e8;
+    margin: 2.5em 0;
+}
+
+/* Inline code */
+#main_content code {
+    background-color: #f2f4f6;
+    border: 1px solid #e1e4e8;
+    border-radius: 4px;
+    padding: 0.15em 0.4em;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 0.9em;
+    color: #24292e;
+}
+
+/* Fenced code blocks. Long command lines scroll rather than breaking layout. */
+#main_content pre {
+    background-color: #f8f9fa;
+    border: 1px solid #e1e4e8;
+    border-radius: 6px;
+    padding: 1em 1.2em;
+    margin: 1.2em 0;
+    overflow-x: auto;
+    line-height: 1.45;
+    font-size: 0.9em;
+}
+
+#main_content pre code {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+}
+
+/* Minimal Rouge syntax highlighting. The slate theme normally supplies this;
+   because this stylesheet replaces the theme's, we define the subset used by
+   the shell/python/yaml snippets in these docs. */
+#main_content .highlight .c,
+#main_content .highlight .c1,
+#main_content .highlight .cm {
+    color: #6a737d;
+    font-style: italic;
+} /* comments */
+#main_content .highlight .k,
+#main_content .highlight .kn,
+#main_content .highlight .kd {
+    color: #d73a49;
+} /* keywords */
+#main_content .highlight .s,
+#main_content .highlight .s1,
+#main_content .highlight .s2 {
+    color: #032f62;
+} /* strings */
+#main_content .highlight .nb,
+#main_content .highlight .nf {
+    color: #6f42c1;
+} /* builtins / functions */
+#main_content .highlight .nv,
+#main_content .highlight .no {
+    color: #e36209;
+} /* variables */
+#main_content .highlight .m,
+#main_content .highlight .mi {
+    color: #005cc5;
+} /* numbers */
 
 /* List styling */
 #main_content ul {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,8 @@
+# Getting started
+
+This guide walks through installing kospex, setting up your directory structure,
+syncing your first repository and exploring the results in the Web UI.
+
 ## Prerequisites
 
 For the best setup experience, we recommend using Homebrew to install the required dependencies on macOS:
@@ -14,97 +19,120 @@ brew install scc
 ```
 
 On other platforms:
-- **Git**: Follow instructions at [https://git-scm.com/downloads](https://git-scm.com/downloads)
-- **Git Credential Manager**: Follow instructions at [https://github.com/git-ecosystem/git-credential-manager](https://github.com/git-ecosystem/git-credential-manager)
-- **scc**: Follow instructions at [https://github.com/boyter/scc](https://github.com/boyter/scc)
+
+- **Git** — follow the instructions at [git-scm.com/downloads](https://git-scm.com/downloads)
+- **Git Credential Manager** — follow the instructions at [git-ecosystem/git-credential-manager](https://github.com/git-ecosystem/git-credential-manager)
+- **scc** — follow the instructions at [boyter/scc](https://github.com/boyter/scc)
 
 ### Linux (Ubuntu tested)
 
-We've tested on ubuntu, you'll need:
-- git (apt install git)
+We've tested on Ubuntu. You'll need:
+
+- git (`apt install git`)
 - homebrew (see instructions above)
-- If you're using Github Only (Organisations with the same credentials, or SAML/SSO) - See below on using the Github CLI
+- If you're using GitHub only (organisations with the same credentials, or SAML/SSO), see the section below on using the GitHub CLI
 
 ### Using the GitHub CLI, classic tokens and SAML
 
-You can configure your git CLI (which kospex wraps) using the GitHub CLI _gh_
+You can configure the git CLI (which kospex wraps) using the GitHub CLI, `gh`.
 
-If you're organisation is using SAML / Single Sign On (e.g. Office365), we've tested that with kospex given the following steps:
-- Create a classic token (gh requires repo, read:org and workflow permissions)
-- Authorise the token for your organisation in the web ui
-- If you haven't done it in the GH WebUI, When doing gh auth (running through the steps to use a token), it will ask you to authorise the token
+If your organisation uses SAML / Single Sign On (e.g. Office 365), we've tested that with kospex using the following steps:
 
-confirm you can clone a repo using
+1. Create a classic token (`gh` requires `repo`, `read:org` and `workflow` permissions)
+2. Authorise the token for your organisation in the web UI
+3. If you haven't done it in the GitHub web UI, `gh auth` will ask you to authorise the token as you work through the steps to use a token
+
+Confirm you can clone a repo:
+
 ```bash
-> gh repo clone ORG/REPO
-```
-If this works, you can configure your git using gh
-```bash
-> gh auth setup-git
+gh repo clone ORG/REPO
 ```
 
-the kgit clone commands will now work with GitHub and your org SSO account that _gh_ uses. 
+If this works, you can configure git using `gh`:
 
-## Step 1: Installation, setup and usage
+```bash
+gh auth setup-git
+```
 
-kospex is currently a python module with commands. It works by analysing cloned repositories on the filesystem.
+The `kgit clone` commands will now work with GitHub and the org SSO account that `gh` uses.
 
-**Optional but strongely recommended** - use a python virtual env.
+## Step 1: Installation
 
-Installing using pip:
+kospex is a Python package with commands. It works by analysing cloned repositories on the filesystem.
 
-> pip install kospex
+**Optional but strongly recommended** — use a Python virtual environment.
 
-For complexity and file type analysis, kospex uses the scc binary (installed in Prerequisites above).
-It is optional, but enables much better file type guessing and provide complexity metrics.
+Install using pip:
 
-### Step 2: Initial kospex setup
+```bash
+pip install kospex
+```
 
-kospex uses a git repositoriy layout for cloning repos to disk.
+For complexity and file type analysis, kospex uses the `scc` binary (installed in Prerequisites above).
+It is optional, but enables much better file type guessing and provides complexity metrics.
 
-The following structure is used \
+## Step 2: Initial kospex setup
+
+kospex uses a git repository layout for cloning repos to disk, with the following structure:
+
+```
 /BASE/GIT_SERVER/ORG/REPO
+```
 
-If you are ok to use the ~/code directory for cloned repos, then run:
-> kospex init --default
+If you're happy to use the `~/code` directory for cloned repos, run:
 
-See section "Git code layout for running analysis" below for more details.
+```bash
+kospex init --default
+```
 
-### Step 3: sync some data and play with some commands
+See [Git code layout for running analysis](#git-code-layout-for-running-analysis) below for more details.
 
-You can also use the _kgit_ command to clone and sync a repo you have access to
+## Step 3: Sync some data and try some commands
 
-> kgit clone https://github.com/mergestat/mergestat-lite
+Use the `kgit` command to clone and sync a repo you have access to:
 
-The above command will clone into the KOSPEX_CODE/GIT_SERVER/ORG/REPO structure
+```bash
+kgit clone https://github.com/mergestat/mergestat-lite
+```
+
+This clones into the `KOSPEX_CODE/GIT_SERVER/ORG/REPO` structure.
 
 Some commands to try:
 
-> kospex developers
->
-> kospex tech-landscape -metadata
+```bash
+kospex developers
+kospex tech-landscape -metadata
+```
 
-### Step 4: Use the Web UI to explore your repos and developers
+## Step 4: Use the Web UI to explore your repos and developers
 
-You can run the Web UI using the following command:
+Start the Web UI:
 
-> kweb
+```bash
+kweb
+```
 
-You can now navigate to http://127.0.0.1:8000
+You can now navigate to [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
+See the [Web UI guide](kweb/) for what each view shows you.
 
 ## Git code layout for running analysis
 
-One option, if you're inspecting code on your own laptop is to use use your home directory.
+If you're inspecting code on your own laptop, one option is to use your home directory:
 
-~/kospex/ \
-We'll place config files and the kospex DB (Sqlite3) in here for sync'ed data \
-~/code/ \
-This should have with a structure like \
-GIT_SERVER/ORG/REPO \
- \
-For example, in your ~/code it might look like: \
-github.com/kospex/kospex \
-github.com/mergestat/mergestat-lite
+| Directory | Purpose |
+| --------- | ------- |
+| `~/kospex/` | Config files and the kospex DB (SQLite3) for synced data |
+| `~/code/` | Cloned repositories, in a `GIT_SERVER/ORG/REPO` structure |
 
-This way we have a nice deterministic way of separating different orgs, potentially different instances (e.g. you have an on premise bitbucket and use GitHub.com) as well.
+For example, your `~/code` might look like:
+
+```
+~/code/
+  github.com/
+    kospex/kospex
+    mergestat/mergestat-lite
+```
+
+This gives a deterministic way of separating different orgs, and different instances as well
+(e.g. you have an on-premise Bitbucket and also use GitHub.com).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,55 +1,104 @@
 # kospex
 
-Kospex is a CLI which aims to _"look at the guts of your code"_ to help gain insights into your developers and technology landscape.
-It uses database structure from the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite) to model data from git repositories.
+Kospex maps the **knowledge**, **technology** and **maintenance risk** hiding in your git repositories.
+
+It answers questions that are surprisingly hard to answer at scale:
+*Who still knows this code? What are we actually built on? What's quietly going stale?*
+
+Kospex works by inspecting cloned repositories and aggregating everything into a single
+queryable database, so you can ask questions across one repo or thousands.
+
+There are two ways to use it:
+- a **CLI** for scanning, querying, reporting and automation
+- a **Web UI** (`kweb`) for navigating the data and insights interactively
+
+It uses the database structure from the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite)
+to model data from git repositories.
 
 ## Getting started
 
-Follow our guide on [Installation and setup](getting-started)
+Follow our guide on [Installation and setup](getting-started).
 
-Also check out the [list of commands](commands) that are part of the kospex toolkit.
+Also check out the [list of commands](commands) that are part of the kospex toolkit,
+and the [Web UI guide](kweb/) for exploring the data.
 
-If you are after some generally useful git commands then take a look at [Useful Git commands](useful-git-commands)
+If you are after some generally useful git commands, take a look at [Useful Git commands](useful-git-commands).
 
-## Key Use Cases and features
+## What kospex gives you
 
- - Identify technology landscape
- - Identify active developers (e.g. who's had their code committer in the last 90 days)
- - Identify key person or offboarding risk
- - Identify potential complexity challenges (or conceptual integrity concerns)
- - Aggregate repo metadata into a single database for easier and faster querying
+### Knowledge mapping
 
- Some better descriptions can be found at [use cases](use-cases).
+Who knows what, and whether they're still around.
+
+- Active developers (e.g. who's committed in the last 90 days) vs. historical contributors
+- Contribution depth at repo, directory and file level
+- Derived code ownership — top and most-recent committers who still work here
+- Collaboration patterns between developers and repositories
+
+### Technology identification
+
+More than just languages — kospex identifies the whole toolchain from filenames, paths and content:
+
+- **Languages** and file types (with complexity metrics via `scc`)
+- **Infrastructure as code** — Docker, Terraform and friends
+- **Package managers and build tools** — npm/yarn/pnpm, pip/uv, Maven, Gradle, Go modules, RubyGems, Composer, Cargo, NuGet
+- **CI/CD pipelines** — GitHub Actions, GitLab CI, Jenkins, Azure DevOps, Bitbucket Pipelines, CircleCI, Buildkite, Travis
+- **Linters and config** — eslint, SQLFluff, and other quality tooling
+
+This gives you a technology landscape you can compare over time — what you're building
+with now, versus twelve months ago.
+
+### Open source libraries
+
+- Declared dependencies extracted from manifest and lock files across supported ecosystems
+- How far behind the current release each dependency is
+- Security advisory counts, sourced from [deps.dev](https://deps.dev)
+
+### Maintenance indicators
+
+Signals that code needs attention — or an owner:
+
+- **Orphaned repos** — no active committer still contributing (`kospex orphans`)
+- **Key person risk** — files and repos with a single active committer, for offboarding
+  and knowledge-transfer planning
+- **Aging and unmaintained code** — based on last commit activity
+- **Out of date libraries** — dependencies well behind current, or with known advisories
+- **Complexity hotspots** — files that change often and are hard to change
+
+Longer write-ups are in [use cases](use-cases).
 
 If some of your repos run off a non-default branch, see [Scanning a non-default branch](branch-aware-sync).
 
 ## General description of aging "things"
 
-Many reports or commands generate a description of active, aging, stale or unmaintained. This description is a simple calculation based on give date using the following default rules.
+Many reports and commands describe something as active, aging, stale or unmaintained.
+This is a simple calculation based on a given date, using the following default rules.
 
 | Description   | Rule |
 | -----------   | ---- |
-| Acitve        | < 90 days |
+| Active        | < 90 days |
 | Aging         | > 90 and < 180 days |
 | Stale         | > 180 and < 365 days |
-| Unmaintained  | >  365 days |
+| Unmaintained  | > 365 days |
 
-There are several places where this description may be used:
- - On the last commit in a repo, to say it looks like it's "aging"
- - On a last updated date of package manager file, where we'd expect them to be updated monthly to quarterly
- - On the release date of a package or libraries we're using.
+There are several places this description may be used:
+- On the last commit in a repo, to say it looks like it's "aging"
+- On the last updated date of a package manager file, where we'd expect updates monthly to quarterly
+- On the release date of a package or library we're using
 
-It's possibly that something labelled "unmaintained" is feature complete and doesn't require changes. However, generally there are any external dependencies, a code or library usually needs a change a couple of times a year.
+It's possible that something labelled "unmaintained" is feature complete and doesn't
+require changes. However, where there are external dependencies, code or a library
+usually needs a change a couple of times a year.
 
 ## Thoughts and articles
 
-["What are orphaned repos?"](https://kospex.io/articles/orphaned-repos/) take a look at some basics of knowledge loss and the challenges.
+["What are orphaned repos?"](https://kospex.io/articles/orphaned-repos/) — some basics of knowledge loss and the challenges.
 
 ["Are security vulnerabilities an indicator of development testing practices?"](https://kospex.io/articles/vulnerabilities-testing-indicator/)
 
 ## What is a kospex?
 
 We're aiming to [k]now your c[o]de by in[spe]cting the haruspe[x].
-From Wikipedia, _The Latin terms haruspex and haruspicina are from an archaic word, hīra = "entrails, intestines"_
-
-So we're going to help look at the "guts of your code" to gain an understanding of the applications, technology landscape (sprawl?) and developers.
+From Wikipedia, _The Latin terms haruspex and haruspicina are from an archaic word, hīra = "entrails, intestines"_ —
+so yes, we do look at the "guts of your code" to understand your applications,
+technology landscape (sprawl?) and developers.

--- a/docs/kweb/index.md
+++ b/docs/kweb/index.md
@@ -1,207 +1,134 @@
-# Kospex Web Interface Documentation
+# Kospex Web UI
 
-## Overview
+`kweb` is the web interface for navigating the data kospex has synced into its database.
+Where the CLI is built for scanning, scripting and reporting, the Web UI is built for
+*exploring* — following a thread from an organisation, to a repo, to a file, to the
+developer who last touched it.
 
-Kospex Web is a comprehensive software development analytics platform that provides insights into code repositories, developer activity, and organizational patterns. The web interface offers interactive dashboards, visualizations, and detailed analysis tools for understanding software development metrics across your organization.
+## Starting the Web UI
 
-## Key Features
+```bash
+kweb
+```
 
-### Core Analytics Views
+Then open [http://127.0.0.1:8000](http://127.0.0.1:8000).
 
-#### 📦 **Repositories**
-- **Purpose**: Browse and analyze all repositories in your organization
-- **Key Metrics**: Commit counts, developer activity, repository health indicators
-- **Filtering**: By organization, git server, or specific criteria
-- **Use Cases**: Repository inventory, health assessment, maintenance planning
-- **Documentation**: [Repositories Documentation](repos.md) *(to be created)*
+You'll need repositories synced into the database first — see
+[Getting started](../getting-started) if you haven't done that yet.
 
-#### 🏢 **Organizations**
-- **Purpose**: View organizational structure and ownership patterns
-- **Key Metrics**: Repository count, active developers per organization
-- **Insights**: Cross-organizational collaboration, ownership distribution
-- **Use Cases**: Portfolio management, organizational restructuring
-- **Documentation**: [Organizations Documentation](orgs.md) *(to be created)*
+> **The Web UI has no authentication.** It binds to `127.0.0.1` by default, so it's only
+> reachable from your own machine. Don't expose it to a network or the internet without
+> putting your own authentication in front of it — everything kospex knows about your
+> code and developers is readable by anyone who can reach the port.
 
-#### 👥 **Developers**
-- **Purpose**: Analyze individual and team contribution patterns
-- **Key Metrics**: Commit history, expertise areas, activity trends
-- **Features**: Individual profiles, collaboration patterns, knowledge mapping
-- **Use Cases**: Performance reviews, team planning, expertise location
-- **Documentation**: [Developers Documentation](developers.md) *(to be created)*
+## Navigation
 
-#### 🔧 **Technology Landscape**
-- **Purpose**: Explore technology stack across your organization
-- **Key Metrics**: Programming languages, frameworks, file type distribution
-- **Visualizations**: Usage statistics, trend analysis, technology adoption
-- **Use Cases**: Technology standardization, migration planning, skill gap analysis
-- **Documentation**: [Technology Landscape Documentation](landscape.md) *(to be created)*
+The main menu maps to the core views:
 
-#### 📊 **Metadata Overview**
-- **Purpose**: High-level dashboard with summary statistics
-- **Key Metrics**: Total repositories, commits, developers, organizations
-- **Features**: At-a-glance organizational health indicators
-- **Use Cases**: Executive reporting, baseline establishment
-- **Documentation**: [Metadata Documentation](metadata.md) *(to be created)*
+| Menu | Path | What it shows |
+| ---- | ---- | ------------- |
+| Summary | `/summary/` | High-level overview of everything synced |
+| Repos | `/repos/` | Repository inventory, activity and health |
+| Orgs | `/orgs/` | Organisations and git servers |
+| Developers | `/developers/` | Contributors, activity and expertise |
+| Opensource | `/osi/` | Open Source Inventory — dependency files and packages |
+| Landscape | `/landscape/` | Technology landscape across your code |
+| Metadata | `/metadata/` | File-level metadata and technology detail |
+| Help | `/help/` | Context-sensitive help |
 
-### Advanced Analysis Tools
+## Core views
 
-#### 🔍 **Dependencies**
-- **Purpose**: Track software dependencies and version management
-- **Features**: Security vulnerability tracking, version analysis
-- **Use Cases**: Security auditing, dependency management, upgrade planning
-- **Documentation**: [Dependencies Documentation](dependencies.md) *(to be created)*
+### Summary
 
-#### 🔥 **Code Hotspots**
-- **Purpose**: Identify files with high commit frequency and complexity
-- **Metrics**: Change frequency, complexity scores, maintenance indicators
-- **Use Cases**: Refactoring prioritization, technical debt management
-- **Documentation**: [Code Hotspots Documentation](hotspots.md) *(to be created)*
+The starting point. Aggregate counts of repositories, developers and organisations,
+with activity status so you can see how much of your estate is active versus aging.
 
-#### 📋 **Supply Chain Analysis**
-- **Purpose**: Visualize dependency relationships and security status
-- **Features**: Interactive bubble charts, security risk assessment
-- **Use Cases**: Supply chain security, dependency impact analysis
-- **Documentation**: [Supply Chain Documentation](supply-chain.md) *(to be created)*
+### Repos
 
-#### 📝 **Commit History**
-- **Purpose**: Browse detailed commit logs and file changes
-- **Features**: Author information, file change statistics, timeline views
-- **Use Cases**: Code archaeology, change impact analysis
-- **Documentation**: [Commit History Documentation](commits.md) *(to be created)*
+Repository inventory. For each repo you can see commit activity, contributor counts and
+last-commit age, which drives the active / aging / stale / unmaintained status described
+on the [home page](../).
 
-#### 🕸️ **Developer Collaboration Graphs**
-- **Purpose**: Visualize collaboration patterns between developers and repositories
-- **Features**: Interactive network visualizations, bubble charts, treemaps
-- **Use Cases**: Team dynamics analysis, knowledge transfer planning
-- **Documentation**: [Collaboration Graphs Documentation](graphs.md) *(to be created)*
+Drilling into a single repo (`/repo/{repo_id}`) gives you its contributors, technologies,
+files and commit history.
 
-#### 📋 **Observations**
-- **Purpose**: Custom analysis results and insights
-- **Features**: Configurable analysis rules, custom reporting
-- **Use Cases**: Policy compliance, custom metrics tracking
-- **Documentation**: [Observations Documentation](observations.md) *(to be created)*
+### Orgs
 
-### Visualization Features
+Organisation and git server level views (`/orgs/`, `/org/{org_key}`). Useful for
+portfolio-level questions — which parts of the business have the most repos, the most
+developers, or the most unmaintained code.
 
-#### 🫧 **Bubble Charts**
-- **Purpose**: Visualize developer contributions and repository relationships
-- **Features**: Interactive filtering, zoom capabilities, status indicators
-- **Customization**: Commit thresholds, time-based filtering
-- **Documentation**: [Bubble Charts Documentation](bubble.md) *(to be created)*
+### Developers
 
-#### 🗺️ **Treemap Views**
-- **Purpose**: Alternative visualization for hierarchical data representation
-- **Features**: Space-efficient visualization, comparative analysis
-- **Use Cases**: Resource allocation visualization, proportional analysis
-- **Documentation**: [Treemap Documentation](treemap.md) *(to be created)*
+Contributor analysis (`/developers/`, `/developer/{id}`). For an individual you can see
+which repos they've committed to, the technologies they've used, and how that has changed
+over time — the basis for offboarding and knowledge-transfer planning.
 
-#### 📈 **Dashboard Views**
-- **Purpose**: Aggregate multiple metrics in customizable dashboards
-- **Features**: Summary cards, trend indicators, status overviews
-- **Use Cases**: Regular monitoring, stakeholder reporting
-- **Documentation**: [Dashboard Documentation](dashboard.md) *(to be created)*
+> Kospex measures commit activity, which reflects *where knowledge sits*, not how well
+> someone does their job. It is not a productivity metric and shouldn't be used as one.
 
-## Navigation and User Interface
+### Opensource (OSI)
 
-### Main Navigation Menu
-- **Repos**: Repository listing and analysis
-- **Orgs**: Organization overview and metrics
-- **Developers**: Individual and team analytics
-- **Landscape**: Technology stack analysis
-- **Metadata**: High-level summary dashboard
-- **Help**: Context-sensitive assistance
+The Open Source Inventory. Shows the dependency and lock files found across your repos,
+when each was last updated, and the packages extracted from them.
 
-### Common Features Across Views
-- **Filtering**: Drill down by various criteria
-- **Sorting**: Customizable data ordering
-- **Export**: Data download capabilities
-- **Responsive Design**: Mobile and desktop compatibility
-- **Dark Mode**: Optional dark theme
+Because a package manager file that hasn't been touched in a year is a strong signal on
+its own, dependency files carry the same active / aging / stale / unmaintained status as
+repositories.
 
-## Data Sources and Integration
+### Landscape
 
-### Supported Git Platforms
-- GitHub (Enterprise and Cloud)
-- GitLab (Enterprise and Cloud)
-- Bitbucket (Server and Cloud)
-- Generic Git repositories
+The technology landscape — languages, infrastructure as code, package managers, pipelines
+and linters detected across your code. `/tech/{tech}` drills into a single technology to
+see which repos use it, and `/tech-change/` compares the landscape over time.
 
-### Data Collection
-- Repository metadata
-- Commit history and statistics
-- Developer information
-- File and dependency analysis
-- Security scanning results
+### Metadata
 
-## Getting Started
+File-level metadata and technology detail, including the file types and complexity metrics
+gathered via `scc`.
 
-### Prerequisites
-- Kospex CLI tool installed and configured
-- Database populated with repository data
-- Web server running (Flask or FastAPI)
+## Analysis views
 
-### Quick Start
-1. Access the web interface at your configured URL
-2. Start with the **Metadata** page for an overview
-3. Use **Repos** to explore individual repositories
-4. Check **Developers** for team analytics
-5. Review **Landscape** for technology insights
+These aren't all in the top menu, but are reachable by drilling down:
 
-### Common Workflows
-- **Repository Health Assessment**: Metadata → Repos → Individual Repository Views
-- **Developer Performance Review**: Developers → Individual Developer Profile → Collaboration Graphs
-- **Technology Audit**: Landscape → Dependencies → Supply Chain Analysis
-- **Security Review**: Dependencies → Supply Chain → Hotspots Analysis
+| View | Path | Purpose |
+| ---- | ---- | ------- |
+| Orphans | `/orphans/` | Repos with no active committer still contributing |
+| Key person | `/key-person/{repo_id}` | Files and repos carrying single-contributor risk |
+| Collaboration | `/collab/{repo_id}` | Who works alongside whom in a repo |
+| File collaboration | `/file-collab/{repo_id}/` | Collaboration at the individual file level |
+| Hotspots | `/hotspots/{repo_id}` | Files that change often and are hard to change |
+| Files | `/files/repo/{repo_id}` | File inventory for a repo |
+| Dependencies | `/dependencies/` | Declared dependencies and how far behind they are |
+| Package check | `/package-check/` | Drag and drop a dependency file to analyse it ad hoc |
+| Commits | `/commits/{repo_id}` | Commit history and individual commit detail |
+| Tenure | `/tenure/` | How long contributors have been active |
+| Observations | `/observations/` | Stored analysis results |
+| Recent | `/recent/` | Recently synced repositories |
 
-## API and Integration
+### Graphs and visualisations
 
-### REST API Endpoints
-- JSON data endpoints for programmatic access
-- Compatible with external dashboard tools
-- Rate limiting and authentication support
+- **Collaboration graphs** (`/graph/{org_key}`) — interactive network views of how
+  developers and repositories connect
+- **Bubble charts** (`/bubble/{id}`) — contribution volume and status at a glance
+- **Treemaps** (`/treemap/{id}`) — proportional views of the same data
 
-### Export Capabilities
-- CSV export for tabular data
-- JSON export for structured data
-- Custom report generation
+## Common workflows
+
+- **Where is our knowledge concentrated?** Orgs → Repos → Key person → Collaboration graph
+- **What are we built on?** Landscape → Opensource → Dependencies
+- **What's been abandoned?** Summary → Orphans → individual repo views
+- **What is this person taking with them?** Developers → individual developer → their repos and technologies
 
 ## Troubleshooting
 
-### Common Issues
-- **Data Not Loading**: Check database connection and data freshness
-- **Slow Performance**: Review data volume and consider filtering
-- **Missing Repositories**: Verify scanning and indexing completion
+- **No data showing** — the database may be empty. Sync at least one repo with
+  `kgit clone` or `kospex sync`, and check `kospex summary` returns results from the CLI.
+- **Missing repositories** — confirm the repo synced successfully; `/recent/` shows what
+  was most recently ingested.
+- **Missing file types or complexity metrics** — check that `scc` is installed, as it
+  drives file type detection and complexity analysis.
+- **Slow pages** — large estates produce large tables; filter by org or server rather than
+  loading everything at once.
 
-### Error Handling
-- Graceful error messages for data loading issues
-- Modal dialogs for network connectivity problems
-- Fallback views for incomplete data
-
-## Future Documentation Pages
-
-The following documentation pages will provide detailed guidance for each feature:
-
-1. **repositories.md** - Repository analysis and management
-2. **organizations.md** - Organizational views and metrics
-3. **developers.md** - Developer analytics and profiles
-4. **landscape.md** - Technology stack analysis
-5. **metadata.md** - Summary dashboard and overview
-6. **dependencies.md** - Dependency tracking and management
-7. **hotspots.md** - Code complexity and maintenance analysis
-8. **supply-chain.md** - Dependency relationship visualization
-9. **commits.md** - Commit history and change analysis
-10. **graphs.md** - Collaboration network visualizations
-11. **observations.md** - Custom analysis and reporting
-12. **bubble.md** - Bubble chart visualizations
-13. **treemap.md** - Treemap visualization guide
-14. **dashboard.md** - Dashboard customization and usage
-
-## Support and Resources
-
-- **Official Documentation**: [kospex.io](https://kospex.io)
-- **GitHub Repository**: Issues and feature requests
-- **Community Support**: User forums and discussion groups
-
----
-
-*This documentation reflects the current state of Kospex Web. For the latest updates and detailed API documentation, visit the official Kospex website.*
+More general help is in [Troubleshooting](../troubleshooting).


### PR DESCRIPTION
Reworks the `docs/` Jekyll site published to docs.kospex.io: broader positioning on the landing page, an accurate Web UI guide, and a fix for CSS that was silently stripping spacing from every page.

## Why

Three related problems:

1. **Positioning was too narrow.** The landing page described kospex only as a CLI that "looks at the guts of your code", and never mentioned the Web UI.
2. **The Web UI docs were largely aspirational** — 14 "*(to be created)*" stub links, a nav menu that didn't match the app, and several capabilities documented that don't exist.
3. **Page formatting was broken sitewide** by missing CSS rules, not by the markdown.

## The CSS root cause

`docs/assets/css/style.css` **replaces** the slate remote theme's stylesheet rather than extending it, so the theme's prose typography and Rouge syntax highlighting were never loaded. Combined with the global `* { margin: 0; padding: 0; }` reset, markdown content had no spacing rules at all:

- **No `p` rule anywhere** — every paragraph rendered with zero margin, running together. This is why `getting-started.md` had accumulated trailing-backslash hard-break hacks: they were compensating for invisible paragraph breaks.
- **No `h3`/`h4` rules** — sub-headings collided with the text above them.
- **No `pre`/`code` rules** — fenced code blocks rendered as unstyled monospace with no background, padding or scroll.
- **Padding bug** — `padding-top: 100px` was overridden by the `padding` shorthand on the following line, letting content slide under the fixed header on narrow viewports.

## Web UI doc corrections

Removed claims not implemented in `src/kweb2.py` or the templates:

- CSV / JSON export and "custom report generation" — no export controls exist
- "REST API … rate limiting and authentication support" — there is **no authentication**; replaced with a security callout that `kweb` binds to `127.0.0.1` and shouldn't be exposed without something in front of it
- "Community forums and discussion groups"
- 14 placeholder links to pages that were never written

Corrected the nav to match the app (Summary and Opensource were both missing) and grounded view paths in real routes (`/osi/`, `/hotspots/{repo_id}`, `/key-person/{repo_id}`, `/package-check/`, …).

Also replaced "performance reviews" as a Developers use case with knowledge-mapping / offboarding framing, plus a note that commit activity shows where knowledge sits and is not a productivity metric.

## Verification

Builds clean under Ruby 3.3.12. Rendered output checked via headless Chrome:

- Paragraph spacing, heading hierarchy, inline code and fenced code blocks render correctly
- Rouge syntax highlighting applied (`.highlight .c`, `.highlight .nb` present in output)
- `document.documentElement.scrollWidth == viewport` — no horizontal page overflow
- Long command lines scroll inside their `pre` rather than widening the page

**Not verified:** rendering below 500px. Headless Chrome on macOS clamps the window to a 500px minimum and crops the screenshot to the requested size, so narrow-viewport screenshots are misleading. The mobile `padding-top: 200px` header clearance was confirmed at 500px, not at 375–390px — worth a quick DevTools responsive-mode check before merge, since merging triggers the live rebuild of docs.kospex.io.

## Note on local preview

`docs/Gemfile` is gitignored and not part of this PR, but for anyone hitting it: Homebrew's default `ruby` has rolled to 4.0.x, and `github-pages` → `commonmarker 0.23.x` requires Ruby `>= 2.6, < 4.0`, so `bundle install` fails to resolve. Use `brew install ruby@3.3` (keg-only) and prepend it to `PATH`. GitHub Pages itself runs Ruby 3.3.4 / Jekyll 3.10 / github-pages 232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)