### PR TITLE
docs: render CLI commands as code fences across command-reference pages

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,9 +19,12 @@ See [kgit](kgit) for more details.
 A simple web interface to view the data in the kospex database.
 
 Run the following command:
-> kweb
 
-Point your browser to http://127.0.0.1:8000
+```bash
+kweb
+```
+
+Point your browser to [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
 ## krunner
 

--- a/docs/kgit.md
+++ b/docs/kgit.md
@@ -1,69 +1,87 @@
 # kgit
 
-The kgit command is helper for some git commands and utilities on repos
+The kgit command is a helper for some git commands and utilities on repos.
 
 ## clone
 
-The clone function is a wrapper around the CLI git installed in your machine.
-It will authenticate with your credentials as it's runing in your shell. 
+The clone function is a wrapper around the CLI git installed on your machine.
+It will authenticate with your credentials as it's running in your shell.
 
-> kgit clone https://github.com/
+```bash
+kgit clone https://github.com/OWNER/REPO
+```
 
-By default, the clone command: \
-clones the repo to the KOSPEX_CODE/SERVER/ORG/REPO file structure and \
-syncs the entire git history to the kospex database. 
+By default, the clone command clones the repo to the `KOSPEX_CODE/SERVER/ORG/REPO`
+file structure and syncs the entire git history to the kospex database.
 
-You can confirm the sync by running the following kospex command
-> kospex list-repos -db
+You can confirm the sync by running the following kospex command:
+
+```bash
+kospex list-repos -db
+```
 
 ### Cloning a list of repos in a file
 
-To clone and sync in bulk you can use the _-filename FILENAME_ switch like: \
-> kgit clone -filename FILENAME
+To clone and sync in bulk you can use the `-filename FILENAME` switch:
 
-For example, the contents of the file might look like: \
-https://github.com/kospex/kospex \
-\# This is a comment \
+```bash
+kgit clone -filename FILENAME
+```
+
+For example, the contents of the file might look like:
+
+```
+https://github.com/kospex/kospex
+# This is a comment
 https://github.com/mergestat/mergestat-lite
-
+```
 
 ## bitbucket
 
-All bitbucket commands require the credentials to be set
-The following environment variables are required: \
-BITBUCKET_USERNAME \
-BITBUCKET_APP_PASSWORD
+All bitbucket commands require the credentials to be set. The following environment
+variables are required:
 
-> kgit bitbucket -test-auth
+- `BITBUCKET_USERNAME`
+- `BITBUCKET_APP_PASSWORD`
+
+```bash
+kgit bitbucket -test-auth
+```
 
 This flag will check if the credentials work, display the status and exit.
 
-> kgit bitbucket -workspace _WORKSPACE_
+```bash
+kgit bitbucket -workspace WORKSPACE
+```
 
-If you want to write all the clone URLs to a file you can use the _-out-repo-list FILENAME_ switch
-> kgit bitbucket -workspace _WORKSPACE_ -out-repo-list FILENAME
+If you want to write all the clone URLs to a file you can use the `-out-repo-list FILENAME` switch:
 
-This can be used with the kgit clone _-filename_ switch as shown above. 
+```bash
+kgit bitbucket -workspace WORKSPACE -out-repo-list FILENAME
+```
+
+This can be used with the `kgit clone -filename` switch as shown above.
 
 ## github
 
-The _github_ function can interact with both authenticated and public orgs and users. 
+The github function can interact with both authenticated and public orgs and users.
 
-For authenticated requests the GITHUB_AUTH_TOKEN must be set in the environment. 
+For authenticated requests the `GITHUB_AUTH_TOKEN` must be set in the environment.
 
-> kgit github -test-auth 
+```bash
+kgit github -test-auth
+```
 
-This _-test-auth_ flag will check if the token (Github PAT) works, display the status and exit.
+This `-test-auth` flag will check if the token (GitHub PAT) works, display the status and exit.
 
 To list the repos for a user:
 
-> kgit github -user _USERNAME_
+```bash
+kgit github -user USERNAME
+```
 
 For an organisation:
 
-> kgit gihub -org _ORG OR TEAM_
-
-
-
-
-
+```bash
+kgit github -org ORG_OR_TEAM
+```

--- a/docs/kospex.md
+++ b/docs/kospex.md
@@ -6,101 +6,125 @@ This is the main command to run analysis, sync directories, find orphaned repos,
 
 List all the developers in the kospex directory, by default, only those with active commits in the last 90 days.
 
-> kospex developers
+```bash
+kospex developers
+```
 
-If you want developers for "all time", use the -all flag
+If you want developers for "all time", use the `-all` flag:
 
-> kospex developers -all
+```bash
+kospex developers -all
+```
 
-If you need to restrict the search to only in a given domain name / server
+If you need to restrict the search to only in a given domain name / server:
 
-> kospex developers -server [DOMAIN_NAME]
+```bash
+kospex developers -server [DOMAIN_NAME]
+```
 
 ## deps
 
-The deps command queries deps.dev API to get information about libraries in a dependency file
+The deps command queries the deps.dev API to get information about libraries in a dependency file.
 
-> kospex deps -file requirements.txt
+```bash
+kospex deps -file requirements.txt
+```
 
-The output will be a table with the following columns
-- package_name
-- package_version
-- days_ago : how many days ago this package was published
-- published_at : date this package was published
-- advisories : number of known security advisories
-- default : is this the default version which is installed as of today
-- versions_behind : how many versions behind is this version
-- source_repo : the git URL for this package if known
-- authors : the number of authors, if we've synced the source_repo to the kospex DB
+The output will be a table with the following columns:
+
+- `package_name`
+- `package_version`
+- `days_ago` — how many days ago this package was published
+- `published_at` — date this package was published
+- `advisories` — number of known security advisories
+- `default` — is this the default version which is installed as of today
+- `versions_behind` — how many versions behind is this version
+- `source_repo` — the git URL for this package if known
+- `authors` — the number of authors, if we've synced the source_repo to the kospex DB
 
 ## sync
 
 The sync command takes all the commit history and adds it to the kospex database.
 
-> kospex sync [DIRECTORY]
+```bash
+kospex sync [DIRECTORY]
+```
 
-Most likely, you'll cd to a repo and then run the following command
+Most likely, you'll cd to a repo and then run the following command:
 
-> kospex sync .
+```bash
+kospex sync .
+```
 
+**Parameters**
 
-*Parameters*
-
-'--no-scc', is_flag=True, default=False, help="Skip scc analysis."
+- `--no-scc` — skip scc analysis.
 
 ## orphans
 
 Orphans occur when a repo no longer has someone working in the organisation or team who's active.
 
-*"Experimental feature - Work in Progress."*
+*"Experimental feature — Work in Progress."*
 
-All you need to do is run the following command
+All you need to do is run the following command:
 
-> kospex orphans
+```bash
+kospex orphans
+```
 
-This will display a table with the following columns
- - _repo_id
- - committers
- - active
- - Orphaned
- - % Here
+This will display a table with the following columns:
 
-If you want to check for the orphan status of only a subset of repos, you can use the -target-list arguments
+- `_repo_id`
+- `committers`
+- `active`
+- `Orphaned`
+- `% Here`
 
-> kospex orphans -target-list FILE_OF_CLONE_URLS
+If you want to check for the orphan status of only a subset of repos, you can use the `-target-list` argument:
 
-The format of this file is a git clone URLs, one per line.
+```bash
+kospex orphans -target-list FILE_OF_CLONE_URLS
+```
 
-*Parameters*
+The format of this file is git clone URLs, one per line.
 
-'-days', type=int, default=90, help='Committed in X days is considered active.(default 90)'
-'-window', type=int, default=365, help='Days to consider for orphaned repos. (default 365)'
-'-target-list', type=click.Path(exists=True), help="A file containing repos to check."
+**Parameters**
 
+- `-days` — committed in X days is considered active (default 90)
+- `-window` — days to consider for orphaned repos (default 365)
+- `-target-list` — a file containing repos to check
 
 ## list-repos
 
-This command either lists all the known repos that have been sync'ed to the database or \
-list the repos found searching a directory path.
+This command either lists all the known repos that have been synced to the database, or
+lists the repos found by searching a directory path.
 
-*By directory*
+**By directory**
 
-> kospex list-repos [DIRECTORY]
+```bash
+kospex list-repos [DIRECTORY]
+```
 
-*From the database*
+**From the database**
 
-> kospex list-repos -db
+```bash
+kospex list-repos -db
+```
 
-If you want to restrict the search to a specific server or domain name, use the -server flag \
+If you want to restrict the search to a specific server or domain name, use the `-server` flag:
 
-> kospex list-repos -db -server [DOMAIN_NAME]
+```bash
+kospex list-repos -db -server [DOMAIN_NAME]
+```
 
-E.g.
+For example:
 
-> kospex list-repos -db -server bitbucket.org
+```bash
+kospex list-repos -db -server bitbucket.org
+```
 
-*Including the Repo ID*
+**Including the Repo ID**
 
-Both -db and the filepath option support the -repo_id flag, which returns the repo_id. \
-The repo_id is used as a key in the format of GIT_SERVER&tilde;OWNER&tilde;REPO \
-So for the repository https://github.com/kospex/kospex the _repo_id would be _github.com&tilde;kospex&tilde;kospex_
+Both `-db` and the filepath option support the `-repo_id` flag, which returns the repo_id.
+The repo_id is used as a key in the format `GIT_SERVER~OWNER~REPO`.
+So for the repository `https://github.com/kospex/kospex` the repo_id would be `github.com~kospex~kospex`.

--- a/docs/krunner.md
+++ b/docs/krunner.md
@@ -1,29 +1,34 @@
 # krunner
 
-The krunner command is used to run a command on all the git repos in a directory. 
-Most of the commands wont use the kospex database with the notable exception of "git-pull".
+The krunner command is used to run a command on all the git repos in a directory.
+Most of the commands won't use the kospex database, with the notable exception of `git-pull`.
 
 ## git-pull
 
-The format for this command is
+The format for this command is:
 
-> krunner git-pull DIRECTORY
+```bash
+krunner git-pull DIRECTORY
+```
 
-By default, this will find all repos in DIRECTORY and attempt a "git pull" as your user. 
+By default, this will find all repos in DIRECTORY and attempt a "git pull" as your user.
 
-**NOTE** - This will NOT download new repositories, it will only sync existing ones thare are aleady on disk.
-
+**NOTE** — this will NOT download new repositories, it will only sync existing ones that are already on disk.
 
 ## osi
 
 Run an open source inventory across all synced repos, extracting dependency
 names and versions and enriching them via deps.dev.
 
-> krunner osi -all
+```bash
+krunner osi -all
+```
 
 You can also scope it to a server, org or repo:
 
-> krunner osi GIT_SERVER~ORG~REPO
+```bash
+krunner osi GIT_SERVER~ORG~REPO
+```
 
 If a repo runs off a non-default branch (e.g. `development` rather than `main`),
 see [Scanning a non-default branch](branch-aware-sync) for how to get an
@@ -31,22 +36,18 @@ accurate inventory.
 
 ## find-docker
 
-This command finds files with the naming convention of Dockerfile and docker-*.yml
+This command finds files with the naming convention of `Dockerfile` and `docker-*.yml`.
 
-> krunner find-docker DIRECTORY
+```bash
+krunner find-docker DIRECTORY
+```
 
-Useful additional switches
+Useful additional switches:
 
- \- images
-
-will attemp to extract the image names from any of the files name and provide a summary of container regisgty as well. 
+- `-images` — will attempt to extract the image names from any of the files and provide a summary of the container registry as well.
 
 So, if you want to find all the docker files and images, run the following command:
 
-> krunner find-docker -images DIRECTORY
-
-
-
-
-
-
+```bash
+krunner find-docker -images DIRECTORY
+```

--- a/docs/useful-git-commands.md
+++ b/docs/useful-git-commands.md
@@ -1,11 +1,14 @@
+# Useful Git commands
 
 ### Get the last author date of a file
 
-By default, when you clone a repo, the file dates will be the clone date and not the last modfied. 
+By default, when you clone a repo, the file dates will be the clone date and not the last modified.
 
-The following Git command returns the last author date of the file (NOT the Committer Date)
+The following Git command returns the last author date of the file (NOT the committer date):
 
-> git log -1 \-\-format=%aD FILENAME
+```bash
+git log -1 --format=%aD FILENAME
+```
 
 The date will be in the RFC2822 format.
 
@@ -13,25 +16,26 @@ The date will be in the RFC2822 format.
 
 How old is the repo? (Date of the first commit)
 
-> git log \-\-reverse \-\-format=%aD \| head -1
+```bash
+git log --reverse --format=%aD | head -1
+```
 
 When was it last changed? (Date of last commit)
 
-> git log \-\-format=%aD -1
+```bash
+git log --format=%aD -1
+```
 
 ### How many authors (developers) are in this repo? (with how many commits)
 
 This nifty command shows all the authors, their email and displays and sorts by number of commits.
 
-> git shortlog -sne
+```bash
+git shortlog -sne
+```
 
-Description of switches from _git shortlog \-\-help_ 
+Description of switches (from `git shortlog --help`):
 
--s, \-\-summary Suppress commit description and provide a commit count summary only.
-
--n, Sort output according to the number of commits per author instead of author alphabetic order.
-
--e, \-\-email Show the email address of each author.
-
-
-
+- `-s`, `--summary` — suppress commit description and provide a commit count summary only.
+- `-n` — sort output according to the number of commits per author instead of author alphabetic order.
+- `-e`, `--email` — show the email address of each author.


### PR DESCRIPTION
The command-reference pages wrote commands as `> cmd` blockquotes, which the site CSS styles as italic grey quote boxes with an accent bar — visually unlike the fenced code blocks on [getting-started](https://docs.kospex.io/getting-started). This converts them to ` ```bash ` fences across all five affected pages so the docs are consistent.

## Pages fixed (31 commands total, formatting only)

- **kospex.md** (12) — also fixed `&tilde;` HTML-entity artifacts in the repo_id example → literal `~`
- **kgit.md** (9) — file-list example moved to a plain code block; typo `kgit gihub` → `kgit github`
- **krunner.md** (5)
- **useful-git-commands.md** (4) — escaped `\-\-` / `\|` blockquote workarounds → literal `--` / `|`; added an H1
- **commands.md** (1)

Across all pages: flags, env vars, column names and switches are now inline code (`-all`, `BITBUCKET_USERNAME`, `--summary`).

## Verification

Built under Ruby 3.3.12 and rendered via headless Chrome. Every page: expected code fences present, **0 blockquotes remaining**, no `tilde` entities or `gihub` typo in output. kgit and kospex screenshotted — both render identically to getting-started's command blocks.

## Deliberately not touched

- The `sync`/`install` words render purple inside shell fences because Rouge's bash lexer treats them as builtins. This is consistent across all pages now (and matches getting-started), but whether to tone down shell highlighting altogether is a separate open decision.
- `kgit.md` still documents `BITBUCKET_APP_PASSWORD` (legacy, retiring 2026-06-09). Out of scope for a formatting PR — flagged for a separate content pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)