### PR TITLE
Support scp-style SSH URLs in kgit clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   resolved dependency stores an integer (0 = up to date) and every unresolved one
   stores `NULL`, paired with its `resolution` category (above). Downstream readers
   that assumed the sentinel should treat `NULL` as "not resolved".
+- Azure DevOps and on-premise Bitbucket repos now clone to a flatter directory
+  (`dev.azure.com/myorg-myproj/myrepo` instead of `dev.azure.com/myorg/myproj/_git/myrepo`),
+  matching the `repo_id` that sync already generates. Existing clones under the old layout are
+  orphaned on disk and can be deleted; no `repo_id` values change.
+- `kgit clone` with no arguments prints help instead of exiting silently, and its help text
+  documents SSH URL support.
 
 ### Fixed
 - **Brace-less git renames are now parsed**. `git log --numstat` only uses the
@@ -106,6 +112,20 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   The Language name is now also a `/tech/` link (matching the repos column), so
   both columns drill into the per-technology view.
   See `changes/202606-landscape-tech-link-urlencode.md`.
+- `kgit clone` now accepts scp-style SSH URLs (`git@host:org/repo.git`), completing the
+  `kgit github -ssh-clone-url -out-repo-list` → `kgit clone -filename` pipeline. Previously
+  every SSH URL failed with `ERROR with <url>`.
+- Repo names containing dots (e.g. `dashboard.js`) no longer truncate when parsed from an SSH
+  URL, which produced a wrong `repo_id` and a wrong on-disk directory.
+- `clone_repo()` resolves the code directory through `HabitatConfig` instead of a bare
+  `os.getenv`, so it no longer depends on a CLI entry point having populated `os.environ` at
+  import. CLI behaviour is unchanged; this fixes a `TypeError` for library callers.
+
+### Security
+- Clone and pull no longer shell out via `os.system`, closing a command-injection path for
+  repo URLs read from a file.
+- Clone destinations are confined to the kospex code directory; a crafted Azure DevOps URL
+  could previously resolve outside it.
 
 ## 0.0.39 - 2026-06-14
 

--- a/src/kgit.py
+++ b/src/kgit.py
@@ -330,6 +330,9 @@ def sync(org, sync_db, url):
         console.log(f"Starting single repository sync for: {url}")
 
         repo_path = kgit.clone_repo(url)
+        if not repo_path:
+            console.print(f"[bold red]Error:[/bold red] Failed to clone {url}")
+            return
         log.info(f"Syncing repository {url} to path: {repo_path}")
         commits = kospex.sync_repo(repo_path)
         console.print(f"Synced {len(commits)} commits")
@@ -487,7 +490,10 @@ def github(no_auth, sync, test_auth, out_repo_list, ssh_clone_url, owner):
             if sync:
                 clone_url = repo.get('clone_url')
                 repo_path = kgit.clone_repo(clone_url)
-                print(f"Syncing repo: {clone_url} in directorty {repo_path}")
+                if not repo_path:
+                    print(f"ERROR: failed to clone {clone_url}, skipping")
+                    continue
+                print(f"Syncing repo: {clone_url} in directory {repo_path}")
                 kospex.sync_repo(repo_path)
 
     table = kgit.get_repos_pretty_table(repos=repos)

--- a/src/kgit.py
+++ b/src/kgit.py
@@ -243,19 +243,29 @@ def import_mailmap(filename):
 
 @cli.command("clone")
 @click.option('-sync', is_flag=True, default=True, help="Sync the repo to the database (Default)")
-@click.option('-filename',  type=click.Path(exists=True), help="File with HTTP git clone URLs")
+@click.option('-filename',  type=click.Path(exists=True), help="File with git clone URLs (HTTPS or SSH)")
 @click.argument('repo',type=click.STRING, required=False)
-def clone(sync, filename,repo):
+@click.pass_context
+def clone(ctx, sync, filename, repo):
     """
     Clone the given repo into our KOSPEX_CODE directory.
-    Example:
+
+    Accepts HTTPS and scp-style SSH URLs:
+
+    \b
     kgit clone https://github.com/ORG/REPO
+    kgit clone git@github.com:ORG/REPO.git
+    kgit clone -filename repos.txt
     """
     # We're going to shell out to git to do the clone
     kospex = Kospex()
 
     if repo and filename:
-        exit("You can't specify both a repo and a filename. Please choose one.")
+        raise click.UsageError("Specify either a repo URL or -filename, not both.")
+
+    if not repo and not filename:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
     if repo:
         repo_path = kgit.clone_repo(repo)

--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -42,7 +42,11 @@ class KospexGit:
 
     @staticmethod
     def parse_ssh_git_url(url):
-        pattern = r"git@(?P<remote>[^:]+):(?P<org>[\w-]+(?:/[\w-]+)*)/(?P<repo>[\w-]+)(?:\.git)?"
+        # Anchored at both ends so a junk suffix is a rejection, not a silent
+        # truncation. Dots are legal in orgs and repo names (e.g. dashboard.js);
+        # each segment must start with a word char so ".git", ".." and "-org"
+        # can never become directory names.
+        pattern = r"^git@(?P<remote>[\w.-]+):(?P<org>\w[\w.-]*(?:/\w[\w.-]*)*)/(?P<repo>\w[\w.-]*?)(?:\.git)?$"
         match = re.match(pattern, url)
 
         if match:

--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -12,6 +12,7 @@ from prettytable import PrettyTable
 
 import kospex_schema as KospexSchema
 import kospex_utils as KospexUtils
+from kospex.habitat_config import HabitatConfig
 from kospex_observation import Observation
 from kospex_query import KospexQuery
 
@@ -584,57 +585,58 @@ class KospexGit:
         return obs
 
     def clone_repo(self, repo_url):
-        """Clone a repo to the kospex code directory"""
-        repo_dir = os.getenv("KOSPEX_CODE")
-        if not os.path.isdir(repo_dir):
-            exit("KOSPEX_CODE directory not found: " + repo_dir)
+        """Clone a repo into the kospex code directory.
 
-        current_dir = os.getcwd()
-        os.chdir(repo_dir)
+        Accepts HTTPS, ssh:// and scp-style (git@host:org/repo.git) URLs.
 
-        # Need to strip a trailing slash if it's there
-        # https://github.com/kospex/kospex/
-        repo_url = repo_url.rstrip("/")
-        # the trailing slash messes with the parsing
+        Args:
+        repo_url (str): The git URL to clone.
 
-        parts = self.extract_git_url_parts(repo_url)
-        remote_org_dir = None
-        print(parts)
-        if parts:
-            remote_org_dir = f"{parts['remote']}/{parts['org']}"
-        else:
-            # TODO - add logging
+        Returns:
+        str: Path to the cloned repo on disk, or None on failure.
+        """
+        code_dir = HabitatConfig.get_instance().code_dir
+        if not code_dir.is_dir():
+            exit(f"KOSPEX_CODE directory not found: {code_dir}\n"
+                 f"Run 'kospex init --create' to create it.")
+
+        # Trailing slashes break the parsers
+        parts = self.parse_git_remote(repo_url.rstrip("/"))
+        if not parts:
+            print(f"ERROR: could not parse git URL: {repo_url}")
             return None
 
-        if not os.path.isdir(remote_org_dir):
-            print("Creating directory: " + remote_org_dir)
-            os.makedirs(remote_org_dir)
+        org_dir = code_dir / parts["remote"] / parts["org"]
+        repo_path = org_dir / parts["repo"]
+
+        # ADO repo names can carry path segments straight from the URL, and
+        # urlparse does not normalise '..'. Resolve both sides — comparing a
+        # resolved path against an unresolved root false-positives wherever the
+        # root is a symlink (macOS symlinks /tmp to /private/tmp).
+        code_root = code_dir.resolve()
+        if not repo_path.resolve().is_relative_to(code_root):
+            print(f"ERROR: refusing to clone outside {code_root}: {repo_path}")
+            return None
+
+        org_dir.mkdir(parents=True, exist_ok=True)
+
+        if repo_path.is_dir():
+            print(f"Repo exists, pulling latest changes: {repo_path}")
+            result = subprocess.run(["git", "pull"], cwd=repo_path, check=False)
         else:
-            print("Directory exists: " + remote_org_dir)
+            print(f"Cloning repo: {repo_url}")
+            # List form (no shell) and an explicit destination: the URL cannot
+            # reach a shell, and '--' stops a hostile URL being read as a flag.
+            result = subprocess.run(
+                ["git", "clone", "--", repo_url, parts["repo"]],
+                cwd=org_dir, check=False)
 
-        os.chdir(remote_org_dir)
-        org_dir = os.getcwd()
-        repo_path = os.path.join(org_dir, parts["repo"])
-        print("Current directory: " + os.getcwd())
+        if result.returncode != 0:
+            print(f"Error cloning or pulling repo: {repo_url}")
+            return None
 
-        status = 0
-
-        if os.path.isdir(parts["repo"]):
-            print("Repo exists: " + parts["repo"])
-            print("Trying pulling latest changes instead ...")
-            os.chdir(parts["repo"])
-            status = os.system("git pull")
-        else:
-            print("Cloning repo: " + repo_url)
-            status = os.system(f"git clone {repo_url}")
-
-        if status != 0:
-            print("Error cloning or pulling repo: " + repo_url)
-            repo_path = None
-
-        os.chdir(current_dir)
-
-        return repo_path
+        # str, not Path: kgit.py:264 concatenates this with a str.
+        return str(repo_path)
 
     def get_latest_commit_datetime(self, repo_id):
         """Get the latest commit datetime for the given repo_id"""

--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -400,61 +400,21 @@ class KospexGit:
 
     def extract_git_url_parts(self, url):
         """
-        Extracts the domain name, organization, and repository name from a given URL.
+        Deprecated: use parse_git_remote().
+
+        Retained so existing callers keep working. parse_git_remote() is the
+        single source of truth and additionally handles scp-style SSH, Azure
+        DevOps and on-premise Bitbucket URLs. Collapsing the remaining parsers
+        is tracked in kospex#94.
 
         Args:
         url (str): The URL to extract information from.
 
         Returns:
-        dict: A dictionary containing the remote, org, repo, and remote_type.
+        dict: A dictionary containing the remote, org, repo, and remote_type,
+        or None if the URL could not be parsed.
         """
-        # Regular expression to match the default pattern
-        pattern = r"^(https?|git|ssh)\:\/\/(?:[\w.-]+@)?([\w.-]+)\/([\w.-]+)\/([\w.-]+)(?:\.git)?$"
-        match = re.match(pattern, url)
-        # There are some Go libraries which use a different URL format from Google
-        # https://go.googlesource.com/oauth2
-        g_pattern = r"(?P<protocol>^\w+)://(?P<domain>[^\/?#]+)/(?P<directory>.*)"
-        google_match = re.match(g_pattern, url)
-
-        # gitlab_pattern = r"(?P<protocol>^https?://)" \
-        gitlab_pattern = (
-            r"(?P<protocol>^\w+)://"
-            r"(?P<hostname>[^/]+)"
-            r"(?P<directories>(?:/[^/]+)*?)/"
-            r"(?P<last_part>[^/]+)$"
-        )
-
-        gitlab_match = re.match(gitlab_pattern, url)
-
-        slashes_count = url.count("/")
-        # Looks like github URLS have 4 slashes,
-        # gitlab URLs have more than 4 slashes (more like 5 or 6 for subprojects),
-        # Google/Go URLs have 3 slashes
-        # TODO - check SSH URLs
-
-        if slashes_count > 4 and gitlab_match:
-            return {
-                "remote": gitlab_match.group("hostname"),
-                "org": gitlab_match.group("directories").removeprefix("/"),
-                "repo": gitlab_match.group("last_part").removesuffix(".git"),
-                "remote_type": gitlab_match.group("protocol"),
-            }
-        elif match:
-            return {
-                "remote": match.group(2),
-                "org": match.group(3),
-                "repo": match.group(4).removesuffix(".git"),
-                "remote_type": match.group(1),
-            }
-        elif google_match:
-            return {
-                "remote": google_match.group("domain"),
-                "org": "",
-                "repo": google_match.group("directory").removesuffix(".git"),
-                "remote_type": google_match.group("protocol"),
-            }
-        else:
-            return None
+        return self.parse_git_remote(url)
 
     @staticmethod
     def generate_repo_id(remote, org, repo):

--- a/tests/test_clone_repo.py
+++ b/tests/test_clone_repo.py
@@ -1,0 +1,128 @@
+"""Tests for KospexGit.clone_repo.
+
+subprocess.run is monkeypatched throughout — no test in this file performs a
+real clone or touches the network. HabitatConfig.with_overrides points the code
+directory at pytest's tmp_path; tests/conftest.py resets the singleton around
+every test.
+"""
+import os
+import subprocess
+
+import pytest
+
+from kospex.habitat_config import HabitatConfig
+from kospex_git import KospexGit
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+
+@pytest.fixture
+def captured_runs(monkeypatch):
+    """Capture subprocess.run calls instead of executing them."""
+    runs = []
+
+    def fake_run(cmd, **kwargs):
+        runs.append({"cmd": cmd, "cwd": kwargs.get("cwd")})
+        return _FakeCompletedProcess(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return runs
+
+
+@pytest.fixture
+def code_dir(tmp_path):
+    """Point KOSPEX_CODE at a throwaway directory for the duration of a test."""
+    config = HabitatConfig.get_instance()
+    with config.with_overrides(KOSPEX_CODE=str(tmp_path)):
+        yield tmp_path
+
+
+def test_clone_repo_accepts_scp_style_ssh_url(code_dir, captured_runs):
+    """The bug this change exists to fix: SSH URLs used to return None."""
+    kg = KospexGit()
+    url = "git@github.com:company-org/dashboard.git"
+
+    result = kg.clone_repo(url)
+
+    expected = code_dir / "github.com" / "company-org" / "dashboard"
+    assert result == str(expected)
+    assert isinstance(result, str), "kgit.py:264 concatenates this with a str"
+    assert len(captured_runs) == 1
+    assert captured_runs[0]["cmd"] == ["git", "clone", "--", url, "dashboard"]
+    assert captured_runs[0]["cwd"] == expected.parent
+
+
+def test_clone_repo_does_not_shell_out(code_dir, captured_runs):
+    """argv is a list and the URL sits after '--', so no shell or argument
+    injection is possible."""
+    kg = KospexGit()
+
+    kg.clone_repo("git@github.com:company-org/dashboard.git")
+
+    cmd = captured_runs[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[:3] == ["git", "clone", "--"]
+
+
+def test_clone_repo_leaves_working_directory_unchanged(code_dir, captured_runs):
+    """clone_repo must not os.chdir — kospex-api's sync agent calls it as a
+    library, where mutating process-global state is a threading hazard."""
+    kg = KospexGit()
+    before = os.getcwd()
+
+    kg.clone_repo("git@github.com:company-org/dashboard.git")
+
+    assert os.getcwd() == before
+
+
+def test_clone_repo_creates_nested_org_directories(code_dir, captured_runs):
+    """GitLab orgs are multi-segment (group/sub) and must nest."""
+    kg = KospexGit()
+
+    result = kg.clone_repo("git@gitlab.com:group/sub/repo.git")
+
+    expected = code_dir / "gitlab.com" / "group" / "sub" / "repo"
+    assert result == str(expected)
+    assert expected.parent.is_dir()
+
+
+def test_clone_repo_pulls_when_the_repo_already_exists(code_dir, captured_runs):
+    repo_dir = code_dir / "github.com" / "company-org" / "dashboard"
+    repo_dir.mkdir(parents=True)
+    kg = KospexGit()
+
+    result = kg.clone_repo("git@github.com:company-org/dashboard.git")
+
+    assert result == str(repo_dir)
+    assert captured_runs[0]["cmd"] == ["git", "pull"]
+    assert captured_runs[0]["cwd"] == repo_dir
+
+
+def test_clone_repo_refuses_destination_outside_the_code_directory(code_dir, captured_runs):
+    """parse_ado_git_url joins remaining path segments straight from urlparse,
+    which does not normalise, so '..' survives into the repo name."""
+    kg = KospexGit()
+
+    result = kg.clone_repo(
+        "https://dev.azure.com/myorg/myproj/_git/../../../../../../etc/passwd")
+
+    assert result is None
+    assert captured_runs == [], "git must never be invoked for a traversal URL"
+
+
+def test_clone_repo_returns_none_for_an_unparseable_url(code_dir, captured_runs):
+    kg = KospexGit()
+
+    assert kg.clone_repo("not-a-url") is None
+    assert captured_runs == []
+
+
+def test_clone_repo_returns_none_when_git_fails(code_dir, monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **kwargs: _FakeCompletedProcess(1))
+    kg = KospexGit()
+
+    assert kg.clone_repo("git@github.com:company-org/dashboard.git") is None

--- a/tests/test_clone_repo_integration.py
+++ b/tests/test_clone_repo_integration.py
@@ -1,0 +1,39 @@
+"""End-to-end clone test — performs a REAL HTTPS clone of a public repo.
+
+Gated: skipped unless KOSPEX_RUN_NETWORK_TESTS is set AND git is on PATH, so
+the default (offline / CI) suite never runs it. Run it deliberately with:
+
+    KOSPEX_RUN_NETWORK_TESTS=1 .venv/bin/python -m pytest \
+        tests/test_clone_repo_integration.py -v
+
+It exists to cover the one thing the unit tests cannot: git actually accepting
+the constructed argv and writing the repo to the computed destination. It is
+the runnable form of the SSH acceptance check that could not run without a key.
+"""
+import os
+import shutil
+
+import pytest
+
+from kospex.habitat_config import HabitatConfig
+from kospex_git import KospexGit
+
+pytestmark = pytest.mark.integration
+
+_SKIP_REASON = "set KOSPEX_RUN_NETWORK_TESTS=1 and ensure git is on PATH to run"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("KOSPEX_RUN_NETWORK_TESTS") or shutil.which("git") is None,
+    reason=_SKIP_REASON,
+)
+def test_clone_repo_https_end_to_end(tmp_path):
+    """A real HTTPS clone lands at the computed path and is a git repo."""
+    config = HabitatConfig.get_instance()
+    with config.with_overrides(KOSPEX_CODE=str(tmp_path)):
+        result = KospexGit().clone_repo("https://github.com/kospex/panopticas.git")
+
+    expected = tmp_path / "github.com" / "kospex" / "panopticas"
+    assert result == str(expected)
+    assert expected.is_dir()
+    assert (expected / ".git").is_dir(), "clone did not produce a git working copy"

--- a/tests/test_kgit.py
+++ b/tests/test_kgit.py
@@ -1,6 +1,7 @@
 """
 Tests for KospexGit
 """
+import pytest
 from kospex_git import KospexGit
 
 def test_parse_git_remote():
@@ -46,3 +47,38 @@ def test_repo_id():
 
     gitlab_repo_id = KospexGit.generate_repo_id("gitlab.com","gitlab/bob","the_repo")
     assert gitlab_repo_id == "gitlab.com~gitlab~~bob~the_repo"
+
+
+SSH_ACCEPT_CASES = [
+    ("git@github.com:company-org/dashboard.git", "github.com", "company-org", "dashboard"),
+    ("git@github.com:company-org/dashboard", "github.com", "company-org", "dashboard"),
+    ("git@github.com:company-org/dashboard.js.git", "github.com", "company-org", "dashboard.js"),
+    ("git@github.com:company.org/repo.git", "github.com", "company.org", "repo"),
+    ("git@gitlab.com:group/sub/repo.git", "gitlab.com", "group/sub", "repo"),
+]
+
+
+@pytest.mark.parametrize("url,remote,org,repo", SSH_ACCEPT_CASES)
+def test_parse_ssh_git_url_accepts(url, remote, org, repo):
+    """scp-style SSH URLs parse, including dotted org and repo names."""
+    parts = KospexGit.parse_ssh_git_url(url)
+    assert parts is not None, f"failed to parse {url}"
+    assert parts["remote"] == remote
+    assert parts["org"] == org
+    assert parts["repo"] == repo
+    assert parts["remote_type"] == "ssh"
+
+
+SSH_REJECT_CASES = [
+    "git@github.com:company-org/.git",
+    "git@github.com:./../etc/passwd",
+    "git@github.com:company-org/repo.git; rm -rf /",
+    "git@github.com:-org/repo.git",
+    "https://github.com/company-org/dashboard.git",
+]
+
+
+@pytest.mark.parametrize("url", SSH_REJECT_CASES)
+def test_parse_ssh_git_url_rejects(url):
+    """Degenerate, traversal-shaped and non-SSH URLs return None, not a partial parse."""
+    assert KospexGit.parse_ssh_git_url(url) is None

--- a/tests/test_kgit.py
+++ b/tests/test_kgit.py
@@ -82,3 +82,25 @@ SSH_REJECT_CASES = [
 def test_parse_ssh_git_url_rejects(url):
     """Degenerate, traversal-shaped and non-SSH URLs return None, not a partial parse."""
     assert KospexGit.parse_ssh_git_url(url) is None
+
+
+DELEGATION_URLS = [
+    "git@github.com:company-org/dashboard.git",
+    "https://dev.azure.com/myorg/myproj/_git/myrepo",
+    "https://github.com/company-org/dashboard.git",
+    "https://gitlab.com/group/sub/repo.git",
+    "https://go.googlesource.com/oauth2",
+    "not-a-url",
+]
+
+
+@pytest.mark.parametrize("url", DELEGATION_URLS)
+def test_extract_git_url_parts_delegates_to_parse_git_remote(url):
+    """One parser, one answer: the deprecated helper must not disagree.
+
+    Before this change extract_git_url_parts had no SSH branch (returning None)
+    and routed ADO URLs through the generic gitlab branch (org 'myorg/myproj/_git'
+    instead of 'myorg-myproj'), so clone and sync disagreed about the same URL.
+    """
+    kg = KospexGit()
+    assert kg.extract_git_url_parts(url) == KospexGit.parse_git_remote(url)

--- a/tests/test_kgit_clone_cli.py
+++ b/tests/test_kgit_clone_cli.py
@@ -1,0 +1,74 @@
+"""CLI-level tests for `kgit clone`.
+
+clone_repo is monkeypatched — these tests exercise argument handling only.
+"""
+from click.testing import CliRunner
+
+import kgit as kgit_module
+
+
+def test_clone_with_no_arguments_shows_help():
+    """Bare `kgit clone` used to fall through both branches and exit silently."""
+    result = CliRunner().invoke(kgit_module.cli, ["clone"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+
+
+def test_clone_help_documents_ssh_urls():
+    result = CliRunner().invoke(kgit_module.cli, ["clone", "--help"])
+
+    assert result.exit_code == 0
+    assert "git@github.com:ORG/REPO.git" in result.output
+
+
+def test_clone_rejects_both_a_url_and_a_filename(tmp_path):
+    repo_list = tmp_path / "repos.txt"
+    repo_list.write_text("git@github.com:company-org/dashboard.git\n")
+
+    result = CliRunner().invoke(kgit_module.cli, [
+        "clone", "git@github.com:company-org/dashboard.git",
+        "-filename", str(repo_list),
+    ])
+
+    assert result.exit_code == 2
+    assert "not both" in result.output
+
+
+def test_clone_passes_a_positional_ssh_url_through(monkeypatch):
+    """The one-off form, not just -filename, must reach clone_repo intact."""
+    seen = []
+    monkeypatch.setattr(
+        kgit_module.kgit, "clone_repo", lambda url: seen.append(url) or None)
+
+    result = CliRunner().invoke(
+        kgit_module.cli, ["clone", "git@github.com:company-org/dashboard.git"])
+
+    assert result.exit_code == 0
+    assert seen == ["git@github.com:company-org/dashboard.git"]
+
+
+def test_clone_filename_round_trip_resolves_every_ssh_url(tmp_path, monkeypatch):
+    """Regression guard for the reported bug.
+
+    `kgit github -ssh-clone-url -out-repo-list` writes scp-style URLs; feeding
+    that file back to `kgit clone -filename` printed 'ERROR with <url>' for every
+    line, because clone_repo returned None. Comment lines are still skipped.
+    """
+    urls = [
+        "git@github.com:company-org/dashboard.git",
+        "git@github.com:company-org/dashboard.js.git",
+        "git@gitlab.com:group/sub/repo.git",
+    ]
+    repo_list = tmp_path / "repos.txt"
+    repo_list.write_text("# a comment\n" + "\n".join(urls) + "\n")
+
+    seen = []
+    monkeypatch.setattr(
+        kgit_module.kgit, "clone_repo", lambda url: seen.append(url) or None)
+
+    result = CliRunner().invoke(
+        kgit_module.cli, ["clone", "-filename", str(repo_list)])
+
+    assert result.exit_code == 0
+    assert seen == urls

--- a/tests/test_kgit_clone_cli.py
+++ b/tests/test_kgit_clone_cli.py
@@ -72,3 +72,47 @@ def test_clone_filename_round_trip_resolves_every_ssh_url(tmp_path, monkeypatch)
 
     assert result.exit_code == 0
     assert seen == urls
+
+
+def test_clone_failure_in_sync_does_not_call_sync_repo(monkeypatch):
+    """A failed clone must not reach sync_repo(None), which raises MissingGitDirectory."""
+    monkeypatch.setattr(kgit_module.kgit, "clone_repo", lambda url: None)
+
+    synced = []
+    monkeypatch.setattr(
+        kgit_module.kospex, "sync_repo", lambda path: synced.append(path))
+
+    result = CliRunner().invoke(
+        kgit_module.cli, ["sync", "git@github.com:company-org/dashboard.git"])
+
+    assert result.exit_code == 0
+    assert synced == [], "sync_repo must not be called after a failed clone"
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_github_sync_skips_repos_that_fail_to_clone(monkeypatch):
+    """One repo failing to clone must not abort the whole github sync loop.
+
+    `github`'s GitHub client (`gh = KospexGithub()`) is constructed inline in
+    the command body, not held as a module-level object, so it's stubbed by
+    patching the class methods it calls rather than swapping an instance.
+    """
+    monkeypatch.setattr(kgit_module.kgit, "clone_repo", lambda url: None)
+
+    synced = []
+    monkeypatch.setattr(
+        kgit_module.kospex, "sync_repo", lambda path: synced.append(path))
+
+    monkeypatch.setattr(
+        kgit_module.KospexGithub, "get_account_type",
+        lambda self, owner: "Organization")
+    monkeypatch.setattr(
+        kgit_module.KospexGithub, "get_repos",
+        lambda self, owner, no_auth=False: [
+            {"clone_url": "https://github.com/company-org/dashboard.git"}])
+
+    result = CliRunner().invoke(
+        kgit_module.cli, ["github", "company-org", "-no-auth", "-sync"])
+
+    assert result.exit_code == 0
+    assert synced == [], "sync_repo must not be called for a repo that failed to clone"


### PR DESCRIPTION
## Summary

`kgit github -ssh-clone-url -out-repo-list repos.txt` writes scp-style SSH URLs (`git@host:org/repo.git`), but `kgit clone -filename repos.txt` could not read them back — every URL failed with `ERROR with <url>`. kospex emitted SSH URLs it could not ingest.

Root cause: `clone_repo()` parsed URLs via `extract_git_url_parts()`, which has no SSH branch, while the sync path already used `parse_git_remote()`, which does. This routes both through the one parser and rewrites `clone_repo()`, fixing the round-trip and a handful of defects found in the same function.

## What changed

- **`parse_ssh_git_url` regex** — dotted org and repo names now parse (`dashboard.js` was truncating to `dashboard`); the pattern is anchored so trailing junk is rejected rather than silently dropped, and each segment must start with a word character so `.git`/`..`/`-org` can't become directory names.
- **`extract_git_url_parts` → delegates to `parse_git_remote`** — SSH, Azure DevOps and on-prem Bitbucket URLs now work at both call sites (`clone_repo` and `get_repo_authors`, which previously returned 0 authors for SSH/ADO repos). Clone and sync now agree on the same URL. Partial progress on #94.
- **`clone_repo` rewrite** — resolves the code directory via `HabitatConfig` (no longer depends on an import-time env side effect, which fixes a `TypeError` for library callers); runs `git` via `subprocess` list-form with an explicit destination instead of `os.system`; confines the clone destination to the code directory; drops `os.chdir` so the function is safe to call as a library.
- **`kgit clone` CLI** — bare `kgit clone` now prints help instead of exiting silently; passing both a URL and `-filename` raises a usage error; help text documents SSH URL support.

## Behaviour change worth noting

Azure DevOps and on-prem Bitbucket repos now clone to a flatter directory (`dev.azure.com/org-project/repo` instead of `dev.azure.com/org/project/_git/repo`), matching the `repo_id` sync already generates. Existing clones under the old layout are orphaned on disk and can be deleted; no `repo_id` values change. See CHANGELOG.

## Testing

- New unit coverage for the parser, `clone_repo` (with `subprocess` mocked — no network), and the CLI surface.
- A gated end-to-end test performs a real HTTPS clone of a public repo, verified passing; it skips by default (`KOSPEX_RUN_NETWORK_TESTS` + git-on-PATH) so the offline suite is unaffected.
- Full suite: 458 passed, 1 gated skip.

## Follow-up

A pre-existing `.git`-suffix-stripping bug in the ADO parser (truncates some repo names) is tracked in #94, where the parser consolidation will fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)