### PR TITLE
docs: lead Bitbucket auth with API token, mark app passwords historical

### DIFF
--- a/docs/kgit.md
+++ b/docs/kgit.md
@@ -38,11 +38,18 @@ https://github.com/mergestat/mergestat-lite
 
 ## bitbucket
 
-All bitbucket commands require the credentials to be set. The following environment
+All bitbucket commands require Atlassian credentials in the environment. The following
 variables are required:
 
-- `BITBUCKET_USERNAME`
-- `BITBUCKET_APP_PASSWORD`
+- `BITBUCKET_API_TOKEN` — an Atlassian API token
+- `BITBUCKET_EMAIL` — your Atlassian account email (or `BITBUCKET_USERNAME`, but not both)
+
+See [Troubleshooting → Bitbucket authentication](troubleshooting#bitbucket-authentication)
+for the token types, required scopes and worked examples.
+
+> *Historical:* the old `BITBUCKET_USERNAME` + `BITBUCKET_APP_PASSWORD` method stopped
+> working on 2026-06-09, when Atlassian permanently disabled all app passwords. Use an
+> API token as above.
 
 ```bash
 kgit bitbucket -test-auth

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,7 +19,7 @@ If `kgit clone` fails, here are the most common causes and solutions:
   git config --global credential.helper manager-core
   ```
 - **For GitHub**: Set up a Personal Access Token with repository access
-- **For Bitbucket**: Configure app passwords or OAuth
+- **For Bitbucket**: Set a `BITBUCKET_API_TOKEN` (see [Bitbucket Authentication](#bitbucket-authentication) below)
 
 #### Network and SSL Issues
 - **Problem**: Clone fails with SSL certificate or network errors


### PR DESCRIPTION
[kgit.md](https://docs.kospex.io/kgit) still presented `BITBUCKET_USERNAME` + `BITBUCKET_APP_PASSWORD` as the *required* variables for bitbucket commands. Atlassian permanently disabled all app passwords on **2026-06-09**, so that method no longer authenticates — the page was documenting a guaranteed failure for any reader following it today.

## Changes

**kgit.md** — reordered the bitbucket section to current state:
- Leads with `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` (what `kospex_bitbucket.py` `get_env_credentials` prefers — `MODE_TOKEN`)
- Links to the canonical [Troubleshooting → Bitbucket Authentication](https://docs.kospex.io/troubleshooting#bitbucket-authentication) section for token types, scopes and worked examples, rather than duplicating that detail (avoids drift between the two pages)
- Keeps a short *historical* note that the old username + app-password method stopped working on 2026-06-09

**troubleshooting.md** — fixed a stale one-liner ("For Bitbucket: Configure app passwords or OAuth") in the general credentials list that contradicted the page's own rewritten Bitbucket Authentication section further down.

## Verification

Built under Ruby 3.3.12 and rendered via headless Chrome:
- kgit bitbucket section now leads with `BITBUCKET_API_TOKEN`; `APP_PASSWORD` appears only inside the historical blockquote
- The cross-page link target `id="bitbucket-authentication"` exists in the built troubleshooting.html
- The stale "app passwords or OAuth" string is gone (0 occurrences)

Formatting/content-correctness only; no command behaviour documented differently. Scoped to auth wiring — no methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)