### PR TITLE
Confine package-check upload to its temp directory (CWE-22)

### DIFF
--- a/src/kweb2.py
+++ b/src/kweb2.py
@@ -1393,9 +1393,23 @@ async def package_check_upload(file: UploadFile = File(...)):
         if not file.filename:
             raise HTTPException(status_code=400, detail="No file selected")
 
+        # Strip any directory components from the client-supplied filename before
+        # joining it onto our temp dir. os.path.join(dir, "/abs") discards dir and
+        # a "../" name traverses out, so the raw name is a path-traversal sink
+        # (CWE-22). basename keeps the meaningful part — assess() dispatches the
+        # parser off it (requirements.txt / package.json / pom.xml / ...).
+        safe_name = os.path.basename(file.filename)
+        if not safe_name or safe_name in (".", ".."):
+            raise HTTPException(status_code=400, detail="Invalid filename")
+
         # Save the uploaded file temporarily
         temp_dir = tempfile.mkdtemp()
-        temp_path = os.path.join(temp_dir, file.filename)
+        temp_path = os.path.join(temp_dir, safe_name)
+
+        # Belt-and-braces: assert the destination stays under the temp dir, the
+        # same containment check clone_repo() uses for clone destinations.
+        if not Path(temp_path).resolve().is_relative_to(Path(temp_dir).resolve()):
+            raise HTTPException(status_code=400, detail="Invalid filename")
 
         # Read and save file content
         content = await file.read()

--- a/tests/test_package_check_upload.py
+++ b/tests/test_package_check_upload.py
@@ -137,3 +137,66 @@ def test_upload_endpoint_does_not_500_on_unresolved_dependency(client, monkeypat
     assert by_name["some-git-dep"]["status"] == "Unresolved spec"
     assert by_name["some-git-dep"]["status"] != "Current"
     assert by_name["requests"]["status"] == "Current"
+
+
+# ---------------------------------------------------------------------------
+# Security regression: path traversal in the package-check upload filename
+# (CWE-22). The route joined tempfile.mkdtemp() with the raw client filename,
+# so an absolute or "../" name could write (then delete) a file outside the
+# temp dir. The fix sanitises the name via os.path.basename plus a containment
+# check on the resolved destination.
+# ---------------------------------------------------------------------------
+import os.path  # noqa: E402
+import tempfile as _tempfile  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+def test_upload_filename_with_traversal_stays_inside_temp_dir(client, monkeypatch):
+    """A "../" in the client filename must not let the write escape the temp dir."""
+    created = {}
+    real_mkdtemp = _tempfile.mkdtemp
+
+    def recording_mkdtemp(*a, **k):
+        d = real_mkdtemp(*a, **k)
+        created["dir"] = d
+        return d
+
+    monkeypatch.setattr(_tempfile, "mkdtemp", recording_mkdtemp)
+
+    captured = {}
+
+    def fake_assess(self, filename, **kwargs):
+        captured["path"] = filename
+        return []
+
+    monkeypatch.setattr("kospex_dependencies.KospexDependencies.assess", fake_assess)
+
+    resp = client.post(
+        "/package-check/upload",
+        files={"file": ("../pwned.json", b"{}", "application/json")},
+    )
+
+    assert resp.status_code == 200
+    assert "path" in captured, "assess was not reached"
+    written = Path(captured["path"]).resolve()
+    tempdir = Path(created["dir"]).resolve()
+    assert written.is_relative_to(tempdir), (
+        f"upload escaped temp dir: {written} is not under {tempdir}")
+    assert written.name == "pwned.json", "the basename must be preserved for parser dispatch"
+
+
+def test_upload_rejects_dot_dot_filename(client, monkeypatch):
+    """A filename of "..' must be rejected outright, not written to the parent dir."""
+    def exploding_assess(self, filename, **kwargs):
+        raise AssertionError("assess must not be reached for a rejected filename")
+
+    monkeypatch.setattr("kospex_dependencies.KospexDependencies.assess", exploding_assess)
+
+    resp = client.post(
+        "/package-check/upload",
+        files={"file": ("..", b"{}", "application/json")},
+    )
+
+    assert resp.status_code == 400
+    # Pin the rejection to the filename sanitiser, not any incidental 400.
+    assert resp.json()["detail"] == "Invalid filename"


### PR DESCRIPTION
## Summary

The `POST /package-check/upload` handler joined `tempfile.mkdtemp()` with the raw client-supplied filename:

```python
temp_path = os.path.join(temp_dir, file.filename)
```

`os.path.join` discards the temp dir when the second argument is absolute, and a `../` filename traverses upward — so the destination could land outside the intended temp directory (CWE-22, path traversal).

## Fix

- Sanitise the filename with `os.path.basename` before joining, and reject empty / `.` / `..` results with HTTP 400.
- The basename is **kept** (not replaced with a random name) because `assess()` selects the dependency parser from it (`requirements.txt`, `package.json`, `pom.xml`, …), so normal uploads are unaffected.
- Add a resolved-containment assertion (`Path(...).resolve().is_relative_to(temp_dir)`) as defense-in-depth — the same check `clone_repo()` uses for clone destinations.

## Tests

Two regression tests, both verified to fail before the change and pass after:

- a traversal filename (`../…`) now stays inside the temp directory;
- a `..` filename is rejected with a 400 (`detail: "Invalid filename"`) rather than reaching the filesystem.

Full suite: 460 passed, 1 gated skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)