### PR TITLE
Run krunner scanners and grep via argv, not a shell (CWE-78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,11 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 - `/package-check/upload` now sanitises the client-supplied filename (`os.path.basename` plus a
   containment check on the resolved path), closing a path-traversal write/delete outside the
   temp directory (CWE-22).
+- `krunner`'s secret-scanner commands (`trufflehog`, `gitleaks`, `semgrep`) and `krunner grep`
+  now invoke their tools via argv lists instead of a shell, closing a command-injection path
+  where a repository's remote-derived identifier (or the grep keyword) reached the shell
+  (CWE-78). The scanners also now run against the intended repository directory rather than the
+  directory kospex was launched from.
 
 ## 0.0.39 - 2026-06-14
 

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import os.path
+from pathlib import Path
 import subprocess
 import sys
 import time
@@ -1202,10 +1203,15 @@ class Kospex:
         return krunner_path
 
     def generate_krunner_filename(self, function=None, ext="out"):
-        """Get the path to a krunner file"""
-        krunner_path = self.get_krunner_directory()
-        # TODO - do better path join method and validate no path traversal .. etc
-        return os.path.join(krunner_path, self.git.get_repo_id() + "." + function + "." + ext)
+        """Absolute path to a krunner report file, guaranteed to sit under the
+        krunner directory. Raises ValueError if the repo-id-derived name would
+        escape it (defense-in-depth against a crafted git remote)."""
+        krunner_path = Path(self.get_krunner_directory()).resolve()
+        name = f"{self.git.get_repo_id()}.{function}.{ext}"
+        candidate = (krunner_path / name).resolve()
+        if not candidate.is_relative_to(krunner_path):
+            raise ValueError(f"refusing krunner filename outside {krunner_path}: {name}")
+        return str(candidate)
 
     def extract_krunner_file_details(self, filename, krunner_home=None):
         """Extract the repo_id and function from a krunner filename"""

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -1108,12 +1108,21 @@ def _run_scanner(argv, cwd, stdout_path=None):
     cwd:  directory the tool runs in, so it scans the intended repo.
     stdout_path: if given, the child's stdout is written to this file
         (trufflehog's -j JSON output); otherwise the tool writes its own file.
-    Returns the CompletedProcess.
+    Returns the CompletedProcess, or None if the tool is not installed.
     """
-    if stdout_path is not None:
-        with open(stdout_path, "wb") as out:
-            return subprocess.run(argv, cwd=cwd, stdout=out, check=False)
-    return subprocess.run(argv, cwd=cwd, check=False)
+    try:
+        if stdout_path is not None:
+            with open(stdout_path, "wb") as out:
+                return subprocess.run(argv, cwd=cwd, stdout=out, check=False)
+        return subprocess.run(argv, cwd=cwd, check=False)
+    except FileNotFoundError:
+        # Tool not on PATH. Don't abort the whole run, and don't leave a
+        # 0-byte report behind — an empty file would trip the caller's
+        # "skip, file exists" guard on the next run and silently mask the repo.
+        if stdout_path is not None and os.path.exists(stdout_path):
+            os.remove(stdout_path)
+        print(f"ERROR: scanner not found on PATH: {argv[0]}")
+        return None
 
 
 @cli.command("trufflehog")
@@ -1148,7 +1157,7 @@ def trufflehog_scan(only_verified, directory):
 
 
 @cli.command("grep")
-@click.option("-keyword", type=click.STRING, help="String to search for.")
+@click.option("-keyword", type=click.STRING, required=True, help="String to search for.")
 @click.argument("directory", type=click.Path(exists=True))
 def grep(keyword, directory):
     """Run a 'grep' on all git repositories found in the given directory."""

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -8,6 +8,7 @@ import json
 import os
 import os.path
 import shlex
+import shutil
 import subprocess
 import sys
 from itertools import count
@@ -1116,6 +1117,11 @@ def _run_scanner(argv, cwd, stdout_path=None):
                 return subprocess.run(argv, cwd=cwd, stdout=out, check=False)
         return subprocess.run(argv, cwd=cwd, check=False)
     except FileNotFoundError:
+        # Only a missing executable is skip-and-continue. A bad cwd or output
+        # directory also raises FileNotFoundError but is a real error — if the
+        # tool itself exists on PATH, re-raise rather than mislabel it.
+        if shutil.which(argv[0]) is not None:
+            raise
         # Tool not on PATH. Don't abort the whole run, and don't leave a
         # 0-byte report behind — an empty file would trip the caller's
         # "skip, file exists" guard on the next run and silently mask the repo.

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -1128,21 +1128,23 @@ def trufflehog_scan(only_verified, directory):
     """Run trufflehog on all git repositories found in the given directory."""
     print("\nDirectory: " + os.path.abspath(directory))
     dirs = KospexUtils.find_repos(directory)
-    cwd = os.getcwd()
     for d in dirs:
         print("\nRepo: " + d)
         kospex.set_repo_dir(d)
-        fname = kospex.generate_krunner_filename(function="TRUFFLEHOG", ext="json")
-        verif = ""
-        if only_verified:
-            verif = "--only-verified"
-        command = f"trufflehog filesystem -j {verif} . 2&> {fname}"
+        try:
+            fname = kospex.generate_krunner_filename(function="TRUFFLEHOG", ext="json")
+        except ValueError as e:
+            print(f"Skipping {d}: {e}")
+            continue
         if not os.path.exists(fname):
-            print(command)
-            os.system(command)
+            argv = ["trufflehog", "filesystem", "-j"]
+            if only_verified:
+                argv.append("--only-verified")
+            argv.append(".")
+            print(f"{' '.join(argv)}  (cwd={d}, output={fname})")
+            _run_scanner(argv, cwd=d, stdout_path=fname)
         else:
             print(f"Skipping, file {fname} exists")
-        os.chdir(cwd)
 
 
 @cli.command("grep")
@@ -1232,17 +1234,18 @@ def gitleaks_scan(directory):
     print("\nDirectory: " + os.path.abspath(directory))
     dirs = KospexUtils.find_repos(directory)
     print(f"About to run gitleaks on {len(dirs)} repos\nThis may take a while ...")
-    cwd = os.getcwd()
     for d in dirs:
         print("\nRepo: " + d)
         kospex.set_repo_dir(d)
-        # print(kospex.git.get_repo_id())
-        fname = kospex.generate_krunner_filename(function="GITLEAKS", ext="json")
+        try:
+            fname = kospex.generate_krunner_filename(function="GITLEAKS", ext="json")
+        except ValueError as e:
+            print(f"Skipping {d}: {e}")
+            continue
         if not os.path.exists(fname):
-            os.system(f"gitleaks detect -r {fname}")
+            _run_scanner(["gitleaks", "detect", "-r", fname], cwd=d)
         else:
             print(f"Skipping, file {fname} exists")
-        os.chdir(cwd)
         print("\n")
 
 
@@ -1298,25 +1301,19 @@ def semgrep(directory):
     """
     print("\nDirectory: " + os.path.abspath(directory))
     dirs = KospexUtils.find_repos(directory)
-    cwd = os.getcwd()
     print("# repos: " + str(len(dirs)))
     for d in dirs:
         print("\nRepo: " + d)
-        # os.chdir(d)
         kospex.set_repo_dir(d)
-        print(kospex.git.get_repo_id())
-        # fname = kospex.generate_krunner_filename(function="SEMGREP",ext="txt")
-        fname = kospex.generate_krunner_filename(function="SEMGREP", ext="json")
+        try:
+            fname = kospex.generate_krunner_filename(function="SEMGREP", ext="json")
+        except ValueError as e:
+            print(f"Skipping {d}: {e}")
+            continue
         if not os.path.exists(fname):
-            # os.system(f"gitleaks detect -r {fname}")
-            os.system(f"semgrep scan --json -o {fname}")
+            _run_scanner(["semgrep", "scan", "--json", "-o", fname], cwd=d)
         else:
             print(f"Skipping, file {fname} exists")
-        # we should output as json, but for inital test, we'll use txt
-        # os.system(f"semgrep scan > {fname}")
-        # os.system(f"semgrep scan --json -o {fname}")
-
-        os.chdir(cwd)
 
 
 @cli.command("find-urls")

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -1154,13 +1154,10 @@ def grep(keyword, directory):
     """Run a 'grep' on all git repositories found in the given directory."""
     print("\nDirectory: " + os.path.abspath(directory))
     dirs = KospexUtils.find_repos(directory)
-    cwd = os.getcwd()
     print("# repos: " + str(len(dirs)))
     for d in dirs:
         print("\nRepo: " + d)
-        os.chdir(d)
-        os.system(f"grep -Rn {keyword} *")
-        os.chdir(cwd)
+        _run_scanner(["grep", "-Rn", "-e", keyword, "."], cwd=d)
 
 
 @cli.command("todo")

--- a/src/krunner.py
+++ b/src/krunner.py
@@ -1101,6 +1101,21 @@ def find_repos(directory):
     kospex.list_repos(directory)
 
 
+def _run_scanner(argv, cwd, stdout_path=None):
+    """Run a scanner tool via subprocess — never a shell.
+
+    argv: the command as a list (no shell string, no interpolation).
+    cwd:  directory the tool runs in, so it scans the intended repo.
+    stdout_path: if given, the child's stdout is written to this file
+        (trufflehog's -j JSON output); otherwise the tool writes its own file.
+    Returns the CompletedProcess.
+    """
+    if stdout_path is not None:
+        with open(stdout_path, "wb") as out:
+            return subprocess.run(argv, cwd=cwd, stdout=out, check=False)
+    return subprocess.run(argv, cwd=cwd, check=False)
+
+
 @cli.command("trufflehog")
 @click.option(
     "--only-verified",

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -1,0 +1,34 @@
+"""Security regression tests for the krunner scanner/grep commands (CWE-78).
+
+The scanner binaries are not installed in CI, so subprocess.run is monkeypatched
+throughout — nothing is executed. These tests prove that tainted values (a
+repo-id-derived filename, a grep keyword) reach subprocess as inert list
+elements, never a shell string.
+"""
+from pathlib import Path
+
+import pytest
+
+from kospex_core import Kospex
+
+
+def _kospex_with(tmp_path, repo_id, monkeypatch):
+    k = Kospex()
+    monkeypatch.setattr(k, "get_krunner_directory", lambda: str(tmp_path))
+    monkeypatch.setattr(k.git, "get_repo_id", lambda: repo_id)
+    return k
+
+
+def test_generate_krunner_filename_is_absolute_and_contained(tmp_path, monkeypatch):
+    k = _kospex_with(tmp_path, "github.com~org~repo", monkeypatch)
+    fname = k.generate_krunner_filename(function="TRUFFLEHOG", ext="json")
+    assert Path(fname).is_absolute()
+    assert Path(fname).parent == tmp_path.resolve()
+    assert Path(fname).name == "github.com~org~repo.TRUFFLEHOG.json"
+
+
+def test_generate_krunner_filename_rejects_escaping_repo_id(tmp_path, monkeypatch):
+    # A crafted repo_id that would traverse out of the krunner dir must be refused.
+    k = _kospex_with(tmp_path, "../../../../etc/passwd", monkeypatch)
+    with pytest.raises(ValueError):
+        k.generate_krunner_filename(function="TRUFFLEHOG", ext="json")

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -1,9 +1,14 @@
-"""Security regression tests for the krunner scanner/grep commands (CWE-78).
+"""Security regression tests for the krunner scanner/grep commands.
+
+These tests cover the fix for two related weaknesses:
+- CWE-78 (OS command injection): the trufflehog/gitleaks/semgrep and grep
+  commands interpolated tainted values into os.system shell strings; the tests
+  prove those values now reach subprocess as inert list elements, never a shell.
+- CWE-22 (path traversal): generate_krunner_filename returns an absolute path
+  contained within the krunner directory.
 
 The scanner binaries are not installed in CI, so subprocess.run is monkeypatched
-throughout — nothing is executed. These tests prove that tainted values (a
-repo-id-derived filename, a grep keyword) reach subprocess as inert list
-elements, never a shell string.
+throughout the subprocess-exercising tests — nothing is executed.
 """
 from pathlib import Path
 
@@ -32,3 +37,47 @@ def test_generate_krunner_filename_rejects_escaping_repo_id(tmp_path, monkeypatc
     k = _kospex_with(tmp_path, "../../../../etc/passwd", monkeypatch)
     with pytest.raises(ValueError):
         k.generate_krunner_filename(function="TRUFFLEHOG", ext="json")
+
+
+import subprocess  # noqa: E402
+
+import krunner  # noqa: E402
+
+
+class _FakeCompleted:
+    def __init__(self, returncode=0):
+        self.returncode = returncode
+
+
+def test_run_scanner_uses_list_argv_and_no_shell(monkeypatch):
+    calls = {}
+
+    def fake_run(argv, **kwargs):
+        calls["argv"] = argv
+        calls["kwargs"] = kwargs
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    krunner._run_scanner(["gitleaks", "detect", "-r", "/x/out.json"], cwd="/repo")
+
+    assert isinstance(calls["argv"], list)
+    assert calls["argv"] == ["gitleaks", "detect", "-r", "/x/out.json"]
+    assert calls["kwargs"].get("cwd") == "/repo"
+    assert calls["kwargs"].get("shell") in (None, False)
+
+
+def test_run_scanner_routes_stdout_to_file(tmp_path, monkeypatch):
+    out_path = tmp_path / "out.json"
+
+    def fake_run(argv, **kwargs):
+        # prove stdout is a writable handle at out_path
+        kwargs["stdout"].write(b"hello")
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    krunner._run_scanner(
+        ["trufflehog", "filesystem", "-j", "."], cwd="/repo", stdout_path=str(out_path))
+
+    assert out_path.read_bytes() == b"hello"

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -144,3 +144,26 @@ def test_trufflehog_no_shell_injection(tmp_path, monkeypatch):
     assert cap["kwargs"].get("stdout") is not None
     assert cap["kwargs"].get("cwd") == repo
     assert cap["kwargs"].get("shell") in (None, False)
+
+
+def test_grep_no_shell_injection(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setattr(krunner.KospexUtils, "find_repos", lambda directory: [str(repo)])
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    evil = "x;$(touch pwned)"
+    result = CliRunner().invoke(krunner.cli, ["grep", "-keyword", evil, str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert captured["argv"] == ["grep", "-Rn", "-e", evil, "."]  # keyword inert, one element
+    assert captured["kwargs"].get("cwd") == str(repo)
+    assert captured["kwargs"].get("shell") in (None, False)

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -167,3 +167,32 @@ def test_grep_no_shell_injection(tmp_path, monkeypatch):
     assert captured["argv"] == ["grep", "-Rn", "-e", evil, "."]  # keyword inert, one element
     assert captured["kwargs"].get("cwd") == str(repo)
     assert captured["kwargs"].get("shell") in (None, False)
+
+
+def test_run_scanner_missing_binary_does_not_raise(monkeypatch):
+    def boom(argv, **kwargs):
+        raise FileNotFoundError(argv[0])
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    # must not raise; returns None
+    assert krunner._run_scanner(["nope-not-installed", "x"], cwd="/repo") is None
+
+
+def test_run_scanner_missing_binary_removes_empty_stdout_file(tmp_path, monkeypatch):
+    out_path = tmp_path / "report.json"
+
+    def boom(argv, **kwargs):
+        raise FileNotFoundError(argv[0])
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    result = krunner._run_scanner(
+        ["nope-not-installed"], cwd="/repo", stdout_path=str(out_path))
+
+    assert result is None
+    assert not out_path.exists(), "a 0-byte report would mask the repo on the next run"
+
+
+def test_grep_requires_keyword(tmp_path):
+    result = CliRunner().invoke(krunner.cli, ["grep", str(tmp_path)])
+    assert result.exit_code != 0
+    assert "keyword" in result.output.lower()

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -174,6 +174,7 @@ def test_run_scanner_missing_binary_does_not_raise(monkeypatch):
         raise FileNotFoundError(argv[0])
 
     monkeypatch.setattr(subprocess, "run", boom)
+    monkeypatch.setattr(krunner.shutil, "which", lambda name: None)
     # must not raise; returns None
     assert krunner._run_scanner(["nope-not-installed", "x"], cwd="/repo") is None
 
@@ -185,11 +186,26 @@ def test_run_scanner_missing_binary_removes_empty_stdout_file(tmp_path, monkeypa
         raise FileNotFoundError(argv[0])
 
     monkeypatch.setattr(subprocess, "run", boom)
+    monkeypatch.setattr(krunner.shutil, "which", lambda name: None)
     result = krunner._run_scanner(
         ["nope-not-installed"], cwd="/repo", stdout_path=str(out_path))
 
     assert result is None
     assert not out_path.exists(), "a 0-byte report would mask the repo on the next run"
+
+
+def test_run_scanner_reraises_real_error_when_tool_exists(monkeypatch):
+    # Tool is on PATH, but the run fails with FileNotFoundError (e.g. a bad cwd).
+    # That must propagate, not be mislabelled as "scanner not found".
+    monkeypatch.setattr(krunner.shutil, "which", lambda name: "/usr/bin/" + name)
+
+    def boom(argv, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", kwargs.get("cwd"))
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    with pytest.raises(FileNotFoundError):
+        krunner._run_scanner(["gitleaks", "detect"], cwd="/no/such/cwd")
 
 
 def test_grep_requires_keyword(tmp_path):

--- a/tests/test_krunner_scanner_security.py
+++ b/tests/test_krunner_scanner_security.py
@@ -81,3 +81,66 @@ def test_run_scanner_routes_stdout_to_file(tmp_path, monkeypatch):
         ["trufflehog", "filesystem", "-j", "."], cwd="/repo", stdout_path=str(out_path))
 
     assert out_path.read_bytes() == b"hello"
+
+
+from click.testing import CliRunner  # noqa: E402
+
+
+def _drive_scanner(command_name, tmp_path, monkeypatch, extra_args=None):
+    """Run a scanner command through one repo whose report filename carries
+    shell metacharacters; capture the subprocess call.
+
+    Returns (result, captured, evil_fname, repo_dir).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    evil_fname = str(tmp_path / "evil~org~repo;$(touch pwned).SCAN.json")
+
+    monkeypatch.setattr(krunner.KospexUtils, "find_repos", lambda directory: [str(repo)])
+    monkeypatch.setattr(krunner.kospex, "set_repo_dir", lambda d: None)
+    monkeypatch.setattr(
+        krunner.kospex, "generate_krunner_filename",
+        lambda function, ext: evil_fname)
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return _FakeCompleted(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    args = [command_name, *(extra_args or []), str(tmp_path)]
+    result = CliRunner().invoke(krunner.cli, args)
+    return result, captured, evil_fname, str(repo)
+
+
+def test_gitleaks_no_shell_injection(tmp_path, monkeypatch):
+    result, cap, evil_fname, repo = _drive_scanner("gitleaks", tmp_path, monkeypatch)
+    assert result.exit_code == 0
+    assert isinstance(cap["argv"], list)
+    assert cap["argv"] == ["gitleaks", "detect", "-r", evil_fname]  # fname inert, one element
+    assert cap["kwargs"].get("cwd") == repo
+    assert cap["kwargs"].get("shell") in (None, False)
+
+
+def test_semgrep_no_shell_injection(tmp_path, monkeypatch):
+    result, cap, evil_fname, repo = _drive_scanner("semgrep", tmp_path, monkeypatch)
+    assert result.exit_code == 0
+    assert cap["argv"] == ["semgrep", "scan", "--json", "-o", evil_fname]
+    assert cap["kwargs"].get("cwd") == repo
+    assert cap["kwargs"].get("shell") in (None, False)
+
+
+def test_trufflehog_no_shell_injection(tmp_path, monkeypatch):
+    result, cap, evil_fname, repo = _drive_scanner("trufflehog", tmp_path, monkeypatch)
+    assert result.exit_code == 0
+    # For trufflehog the report path is the stdout target, not an argv element,
+    # so it never touches the command line at all.
+    assert cap["argv"][:3] == ["trufflehog", "filesystem", "-j"]
+    assert "." in cap["argv"]
+    assert evil_fname not in cap["argv"]
+    assert cap["kwargs"].get("stdout") is not None
+    assert cap["kwargs"].get("cwd") == repo
+    assert cap["kwargs"].get("shell") in (None, False)


### PR DESCRIPTION
## Summary

`krunner`'s secret-scanner commands (`trufflehog`, `gitleaks`, `semgrep`) built a per-repo report filename from a repository's remote-derived identifier and interpolated it into an `os.system` shell string; `krunner grep` interpolated its `-keyword` the same way. Because the scanned repo's remote is attacker-influenceable, a crafted identifier (or keyword) could inject a shell command (CWE-78). This converts all four to `subprocess.run` argv lists, so those values become inert arguments a shell never sees.

## What changed

- **`generate_krunner_filename`** now returns an absolute path guaranteed to sit under the krunner directory, raising `ValueError` if a crafted identifier would escape it (defense-in-depth; resolves a standing traversal TODO).
- **`_run_scanner` helper** runs each tool via `subprocess.run([...], cwd=repo_dir)` with no shell. trufflehog's JSON is captured via the child's stdout (replacing a malformed `2&>` redirect that would also have corrupted the JSON with stderr).
- **All four commands** now run with `cwd` set to the repo, which additionally fixes a pre-existing bug where the scanners scanned the directory kospex was launched from rather than the target repo.
- **Robustness:** a missing scanner binary now skips the repo and continues (instead of aborting), without leaving a 0-byte report that would silently mask the repo on a later run; a genuine bad-`cwd`/output-path error still surfaces rather than being mislabelled. `krunner grep` now requires `-keyword`.

## Testing

New security regression tests assert that a metacharacter-laden identifier/keyword reaches `subprocess.run` as a single inert list element (never shell-split), that `cwd` is the repo, and that no shell is used. The scanner binaries aren't needed — `subprocess.run` is monkeypatched throughout.

Full suite: 405 passed, 68 skipped (pre-existing web-endpoint skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)