### PR TITLE
deps: panopticas>=0.0.18 + guard the tag contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "prettytable==3.17.0",
     "dateutils",
     "packaging",
-    "panopticas==0.0.17",
+    "panopticas>=0.0.18",
     "python-dotenv",
     "sqlite-utils",
     "requests==2.33.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mergedeep==1.3.4
 mkdocs-get-deps==0.2.2
 mkdocs==1.6.1
 packaging==26.3
-panopticas==0.0.17
+panopticas==0.0.18
 pathspec==1.1.1
 platformdirs==4.11.1
 pluggy==1.6.0

--- a/tests/test_panopticas_tag_contract.py
+++ b/tests/test_panopticas_tag_contract.py
@@ -1,0 +1,66 @@
+"""Guards the panopticas tag contract kospex actually depends on.
+
+`pyproject.toml` declares `panopticas>=0.0.18` — a floor, not an exact pin, so
+a kospex install can pick up any newer panopticas without a kospex release.
+That is deliberate (it decouples the release cadences and avoids resolution
+clashes), but it removes the version guard that an exact pin provided.
+
+The risk it removes protection from is specific and **silent**: kospex caches
+panopticas tags as `file_metadata.tech_type` and queries them with
+`tech_type LIKE '%|tag|%'`. If panopticas stops emitting a tag kospex matches
+on, those queries return *empty* rather than raising — dependency inventories
+quietly report nothing instead of failing.
+
+Panopticas' own test suite cannot catch this: it has no idea which of its tags
+kospex depends on. So the assertion belongs here.
+
+Scope: as of panopticas 0.0.18, kospex matches on exactly **one** tag,
+`dependencies`, in two places in `kospex_query.py`. Keep this file in step with
+that — if kospex starts querying another tag literal, add it to REQUIRED_TAGS.
+"""
+import panopticas.core as panopticas_core
+import pytest
+
+# The only panopticas tag literals kospex matches on. Sourced by grepping for
+# `%|...|%` across the kospex modules; extend when a new literal is introduced.
+REQUIRED_TAGS = ["dependencies"]
+
+# Files that must carry each required tag for kospex's dependency inventory to
+# work. These are the manifests kospex's own extractor registry treats as
+# package files, so a regression here breaks `get_dependency_files()`.
+DEPENDENCY_MANIFESTS = [
+    "pyproject.toml",
+    "requirements.txt",
+    "package.json",
+    "go.mod",
+    "pom.xml",
+    "setup.py",   # added in panopticas 0.0.18
+    "setup.cfg",  # added in panopticas 0.0.18
+]
+
+
+@pytest.mark.parametrize("filename", DEPENDENCY_MANIFESTS)
+def test_dependency_manifests_still_carry_the_dependencies_tag(filename):
+    """Each known manifest must still be tagged `dependencies`.
+
+    Fails if a panopticas upgrade renames or drops the tag, which would
+    otherwise make `tech_type LIKE '%|dependencies|%'` silently return nothing.
+    """
+    tags = panopticas_core.get_filename_metatypes(filename)
+    assert "dependencies" in tags, (
+        f"panopticas no longer tags {filename!r} as 'dependencies' "
+        f"(got {tags!r}). kospex queries tech_type LIKE '%|dependencies|%', "
+        f"which will now return empty rather than error."
+    )
+
+
+@pytest.mark.parametrize("tag", REQUIRED_TAGS)
+def test_required_tag_is_still_emitted_somewhere(tag):
+    """Sanity check that the tag vocabulary still contains what kospex queries."""
+    emitted = set()
+    for filename in DEPENDENCY_MANIFESTS:
+        emitted.update(panopticas_core.get_filename_metatypes(filename))
+    assert tag in emitted, (
+        f"panopticas emits no {tag!r} tag for any known dependency manifest; "
+        f"kospex's tech_type queries for it will return empty."
+    )


### PR DESCRIPTION
Picks up [panopticas 0.0.18](https://pypi.org/project/panopticas/0.0.18/), which detects `setup.py` and `setup.cfg` as Python dependency manifests (kospex/panopticas#21).

## Two changes

```
pyproject.toml     panopticas==0.0.17  ->  panopticas>=0.0.18
requirements.txt   panopticas==0.0.17  ->  panopticas==0.0.18
+ tests/test_panopticas_tag_contract.py
```

## Why the exact pin becomes a floor

kospex has pinned panopticas exactly since 0.0.16. That had two costs:

1. **A panopticas release reached no kospex user until a kospex release shipped the bump.** Publishing to PyPI wasn't "shipping" for panopticas' only real consumer.
2. **Anything else in a user's environment needing a different panopticas was unresolvable**, with no way to work around it locally.

A floor decouples the two release cadences. `requirements.txt` keeps the exact `==0.0.18` — it ships in neither the wheel nor the sdist, so it constrains no installer; its job is giving Dependabot the concrete version set that actually shipped. The deploy runbook regenerates it from the clean wheel venv and gates it against the SBOM at release time.

## Why a guard test comes with it

The exact pin was protecting against something real, so it's **replaced, not dropped**.

panopticas tag changes break kospex **silently**. `tech_type` is cached at sync time and queried with `LIKE '%|tag|%'`, so a renamed or dropped tag makes those queries return *empty* rather than raise — a dependency inventory quietly reports nothing instead of failing. panopticas' own test suite can't catch this; it has no idea which of its tags kospex depends on.

The contract turns out to be narrow. Across 19 kospex modules plus `kweb2`, kospex matches exactly **one** panopticas tag literal:

```
2  %|dependencies|%     both in kospex_query.py
```

Worth noting kospex never queried the AI tags at all, so 0.0.17's breaking rename (`Claude Code` -> `instructions`) never actually affected kospex.

`tests/test_panopticas_tag_contract.py` asserts the known dependency manifests still carry `dependencies`, with a failure message that names the consequence. `REQUIRED_TAGS` is documented to be extended if kospex starts matching another literal.

**The guard is not decoration.** Run against the panopticas 0.0.17 that was installed in the venv, it fails:

```
AssertionError: panopticas no longer tags 'setup.py' as 'dependencies' (got []).
kospex queries tech_type LIKE '%|dependencies|%', which will now return empty
rather than error.
2 failed, 6 passed
```

After upgrading to 0.0.18: `8 passed`.

## Testing

Full suite on panopticas 0.0.18: **451 passed, 75 skipped**.

## Not breaking — but a re-sync is needed

0.0.18 **adds** tags only; nothing is renamed or removed, so no existing `tech_type` query changes behaviour.

`setup.py` / `setup.cfg` will not appear in an existing database until repos are re-synced, since `tech_type` is cached at sync time. `kospex_core.py` tracks `last_panopticas_version` and re-syncs when it changes, so this bump triggers re-tagging for repos synced afterwards.

## Follow-on

Prerequisite for #137 — parsing `setup.py` / `setup.cfg` `install_requires` into `dependency_data`. Tagging makes the files *visible* to `get_dependency_files()`; it does not extract their dependencies. Best done after #29 so the declarations route through a corrected parser.

Worth considering separately: panopticas carries breaking changes within `0.0.x` (0.0.17 renamed tags), so a version *ceiling* would be false comfort — a range can only protect you if upstream versioning encodes breakage. A stated panopticas policy for tag changes would make future renames cappable; the guard test is the interim answer.
