### PR TITLE
fix: unresolved dependencies reported as healthy (#29, #109)

### DIFF
--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -756,38 +756,74 @@ class KospexDependencies:
 
         return p_template
 
+    # Leading `name` plus optional `[extras]` of a PEP 508 requirement. Used to
+    # recover the *declared* specifier text, which must be preserved verbatim —
+    # see the "multiple" branch below.
+    _PYPI_NAME_EXTRAS_RE = re.compile(r"^\s*[A-Za-z0-9._-]+\s*(?:\[[^\]]*\])?\s*")
+
     def parse_pypi_package_declaration(self, package_declaration):
-        """Parse a PyPi package declaration into a dictionary"""
-        # TODO - need to double check the version specifiers as described in:
-        # https://packaging.python.org/en/latest/specifications/version-specifiers/
-        # They are claiming a lot of different ways to specify versions
-        package = {}
-        version_spec = None
-        single_specifier = True
+        """Parse a PyPi package declaration into a dictionary.
 
-        match = re.match(r"([a-zA-Z0-9_-]+)(.+)", package_declaration)
+        Returns ``{"package_name", "package_version", "version_type"}``, or
+        ``None`` when the line is not a requirement at all (a URL, an ``-e``
+        or ``-r`` directive, a blank line). Callers treat ``None`` as "not a
+        package declaration", not as "no version".
 
-        if match:
-            package["package_name"] = match.group(1)
-            package["package_version"] = match.group(2)
+        An unversioned declaration is a *valid* requirement and returns a
+        record with an empty ``package_version`` — it is never dropped. The
+        previous implementation returned ``None`` for it, and
+        ``parse_pip_requirements_file`` discards falsy results, so unpinned
+        packages never reached ``dependency_data``. Observed on a real repo:
+        a requirements.txt declaring ten packages, nine unpinned, produced a
+        single row.
 
-        if "," in package_declaration:
-            single_specifier = False
-            package["version_type"] = "multiple"
-        elif ">=" in package_declaration:
-            version_spec = ">="
-        elif "~=" in package_declaration:
-            version_spec = "~="
-        elif "==" in package_declaration:
-            version_spec = "=="
-        else:
-            print(f"Unknown version type in {package_declaration}")
+        Parsing is delegated to ``packaging.requirements.Requirement`` (PEP
+        508) rather than substring-matching operators. The old approach tested
+        operators against the whole line *including the environment marker*, so
+        ``requests; sys_platform == 'win32'`` split on the marker's ``==`` and
+        yielded a package named ``"requests; sys_platform "``.
+
+        Two deliberate non-normalisations, both because ``package_name`` and
+        ``package_version`` are part of the ``dependency_data`` primary key —
+        rewriting either inserts duplicate rows on re-sync instead of updating:
+
+        * the declared name is kept as written (``MarkupSafe``, not
+          ``markupsafe``), so ``packaging`` is used to parse, never to rename;
+        * for a multi-specifier line the declared text is preserved verbatim.
+          ``str(SpecifierSet)`` sorts its members, turning ``>=1.0,<2.0`` into
+          ``<2.0,>=1.0``.
+        """
+        if not package_declaration:
             return None
 
-        if single_specifier:
-            package["package_name"] = package_declaration.split(version_spec)[0]
-            package["package_version"] = package_declaration.split(version_spec)[1]
-            package["version_type"] = version_spec
+        # Strip the environment marker before parsing. Markers routinely contain
+        # `==` / `>=`, which is what misled the operator-matching implementation.
+        spec_part = package_declaration.split(";", 1)[0].strip()
+        if not spec_part:
+            return None
+
+        try:
+            requirement = Requirement(spec_part)
+        except InvalidRequirement:
+            # Not a requirement line — a URL, `-e .`, `-r other.txt`, or junk.
+            # pypi_assess falls back to source-repo URL extraction for these.
+            return None
+
+        package = {"package_name": requirement.name}
+        specifiers = list(requirement.specifier)
+
+        if not specifiers:
+            # Declared with no version: unpinned, or version-less with extras
+            # and/or a marker. A real declaration, so it is recorded.
+            package["package_version"] = ""
+            package["version_type"] = None
+        elif len(specifiers) > 1:
+            # Preserve the declared text, not packaging's sorted rendering.
+            package["package_version"] = self._PYPI_NAME_EXTRAS_RE.sub("", spec_part).strip()
+            package["version_type"] = "multiple"
+        else:
+            package["package_version"] = specifiers[0].version
+            package["version_type"] = specifiers[0].operator
 
         return package
 

--- a/src/templates/supply_chain.html
+++ b/src/templates/supply_chain.html
@@ -298,9 +298,15 @@
                 .domain([0, d3.max(data.nodes, d => d.versions_behind)])
                 .range([minSize, maxSize]);
 
-            // Add size to each node based on versions_behind
+            // Add size to each node based on versions_behind.
+            // Size encodes *how far behind* a package is, and an unresolved
+            // package has no such value. d3.scaleLinear() coerces null to 0 and
+            // returns the range minimum, which would draw it smallest — reading
+            // as "least versions behind". Give it a fixed mid size instead, so
+            // magnitude is never implied; the grey fill carries the status.
+            const unresolvedSize = (minSize + maxSize) / 2;
             data.nodes.forEach(node => {
-                node.size = sizeScale(node.versions_behind);
+                node.size = isUnresolved(node) ? unresolvedSize : sizeScale(node.versions_behind);
             });
 
             // Set up the SVG
@@ -328,8 +334,17 @@
 
             // Color scale based on status
             const color = d3.scaleOrdinal()
-                .domain(["green", "yellow", "orange", "red"])
-                .range(["#4CAF50", "#FFF176", "#FF9800", "#F44336"]);
+                .domain(["green", "yellow", "orange", "red", "grey"])
+                .range(["#4CAF50", "#FFF176", "#FF9800", "#F44336", "#9E9E9E"]);
+
+            // An unresolved dependency carries versions_behind === null (PR #106
+            // normalised the old "Unknown"/"" sentinels). In JS `null <= 2` is
+            // TRUE, so without this guard an unresolved package renders green /
+            // "Up to Date" — the most reassuring state available, for a package
+            // whose version could not be determined at all.
+            function isUnresolved(d) {
+                return d.versions_behind === null || d.versions_behind === undefined;
+            }
 
             // Create the simulation
             const simulation = d3.forceSimulation(data.nodes)
@@ -369,8 +384,8 @@
                                </a>
                             </p>                            
                             <p><strong>Published:</strong> ${formatDate(d.publishedAt)}</p>
-                            <p><strong>Versions behind:</strong> ${d.versions_behind}</p>
-                            <p><strong>Advisories:</strong> ${d.advisories}</p>
+                            <p><strong>Versions behind:</strong> ${isUnresolved(d) ? "unknown" : d.versions_behind}</p>
+                            <p><strong>Advisories:</strong> ${d.advisories ?? "unknown"}</p>
                             <p><strong>Malware detected:</strong> ${d.malware ? "Yes" : "No"}</p>
                             <div class="status ${getStatusClass(d)}">${getStatusText(d)}</div>
                         </div>
@@ -384,6 +399,7 @@
                 .style("fill", d => {
                     if (d.malware) return color("red");
                     if (d.advisories > 0) return color("orange");
+                    if (isUnresolved(d)) return color("grey");
                     const monthsBehind = d.versions_behind;
                     if (monthsBehind <= 2) return color("green");
                     if (monthsBehind <= 6) return color("yellow");
@@ -398,7 +414,7 @@
 
             // Add tooltips
             node.append("title")
-                .text(d => `${d.name} v${d.version}\nPublished: ${formatDate(d.publishedAt)}\nVersions behind: ${d.versions_behind}\nAdvisories: ${d.advisories}\nMalware: ${d.malware}`);
+                .text(d => `${d.name} v${d.version}\nPublished: ${formatDate(d.publishedAt)}\nVersions behind: ${isUnresolved(d) ? "unknown" : d.versions_behind}\nAdvisories: ${d.advisories ?? "unknown"}\nMalware: ${d.malware}`);
 
             // Update positions on each tick
             simulation.on("tick", () => {
@@ -465,7 +481,8 @@
                 { color: "green", text: "Up to date (0-2 versions behind)" },
                 { color: "yellow", text: "Slightly outdated (2-6 versions behind)" },
                 { color: "orange", text: "Outdated or has advisories" },
-                { color: "red", text: "Has malware or very outdated" }
+                { color: "red", text: "Has malware or very outdated" },
+                { color: "grey", text: "Unresolved — version could not be determined" }
             ];
 
             legendItems.forEach(item => {
@@ -493,6 +510,7 @@
             function getStatusClass(d) {
                 if (d.malware) return "red";
                 if (d.advisories > 0) return "orange";
+                if (isUnresolved(d)) return "grey";
                 if (d.versions_behind <= 2) return "green";
                 if (d.versions_behind <= 6) return "yellow";
                 return "orange";
@@ -502,6 +520,7 @@
             function getStatusText(d) {
                 if (d.malware) return "Malware Detected";
                 if (d.advisories > 0) return "Has Security Advisories";
+                if (isUnresolved(d)) return "Unresolved (version unknown)";
                 if (d.versions_behind <= 2) return "Up to Date";
                 if (d.versions_behind <= 6) return "Slightly Outdated";
                 return "Outdated";

--- a/tests/test_pypi_declaration_parsing.py
+++ b/tests/test_pypi_declaration_parsing.py
@@ -1,0 +1,164 @@
+"""Regression tests for `parse_pypi_package_declaration` — issue #29.
+
+The original implementation substring-tested version operators against the
+**whole declaration, including the environment marker**, then split on the first
+operator it found:
+
+    elif ">=" in package_declaration:   version_spec = ">="   # tested before ~=
+    ...
+    package["package_name"]    = package_declaration.split(version_spec)[0]
+    package["package_version"] = package_declaration.split(version_spec)[1]
+
+Four consequences, all covered below:
+
+1. Environment markers were not stripped, so `requests; sys_platform == 'win32'`
+   split on the *marker's* `==` and produced a package named
+   `"requests; sys_platform "`.
+2. Operator precedence was wrong — `>=` was tested before `~=`, so
+   `numpy~=2.3.3; python_version >= "3.14"` split on the marker's `>=` and the
+   name absorbed the real specifier.
+3. Neither field was stripped, leaving `"hypothesis "` / `" 3.30"`.
+4. Unpinned declarations and `<`, `<=`, `!=`, `===` specs returned ``None``.
+   `parse_pip_requirements_file` drops falsy results, so those packages never
+   reached `dependency_data` at all.
+
+Defect 4 is the damaging one. Observed on a real synced repo,
+`theskumar/python-dotenv/requirements.txt` declares ten packages, nine of them
+unpinned. `dependency_data` held exactly one — `pytest`, the only line carrying
+a specifier. A 90% loss, silent.
+
+**Names are not canonicalised.** `package_name` and `package_version` are both
+part of the `dependency_data` primary key, so rewriting `MarkupSafe` to
+`markupsafe` would insert duplicate rows on re-sync rather than update existing
+ones. `packaging` is used to *parse* the declaration, never to rename it.
+"""
+import pytest
+
+from kospex_dependencies import KospexDependencies
+
+
+@pytest.fixture
+def kd():
+    return KospexDependencies.__new__(KospexDependencies)
+
+
+class TestEnvironmentMarkers:
+    """Markers must be stripped before the version is parsed (defects 1 and 2)."""
+
+    def test_marker_with_no_version_does_not_leak_into_the_name(self, kd):
+        result = kd.parse_pypi_package_declaration("requests; sys_platform == 'win32'")
+        assert result is not None
+        assert result["package_name"] == "requests"
+        assert result["package_version"] == ""
+
+    def test_marker_operator_does_not_win_over_the_real_specifier(self, kd):
+        result = kd.parse_pypi_package_declaration(
+            'numpy~=2.3.3; python_version >= "3.14"'
+        )
+        assert result is not None
+        assert result["package_name"] == "numpy"
+        assert result["package_version"] == "2.3.3"
+        assert result["version_type"] == "~="
+
+
+class TestWhitespace:
+    """Neither field may carry surrounding whitespace (defect 3)."""
+
+    def test_spaces_around_the_operator_are_stripped(self, kd):
+        result = kd.parse_pypi_package_declaration("hypothesis >= 3.30")
+        assert result is not None
+        assert result["package_name"] == "hypothesis"
+        assert result["package_version"] == "3.30"
+        assert result["version_type"] == ">="
+
+
+class TestUnpinnedDeclarations:
+    """A declaration with no version must be recorded, not dropped (defect 4)."""
+
+    def test_bare_package_is_recorded_with_an_empty_version(self, kd):
+        result = kd.parse_pypi_package_declaration("requests")
+        assert result is not None, (
+            "a bare, unpinned requirement must still be recorded — dropping it "
+            "hides the least reproducible way to declare a dependency"
+        )
+        assert result["package_name"] == "requests"
+        assert result["package_version"] == ""
+
+    def test_extras_without_a_version_are_recorded(self, kd):
+        result = kd.parse_pypi_package_declaration("httpx[cli,http2]")
+        assert result is not None
+        assert result["package_name"] == "httpx"
+        assert result["package_version"] == ""
+
+
+class TestOperatorCoverage:
+    """Every PEP 440 operator must parse, not just >=, ~= and == (defect 4)."""
+
+    @pytest.mark.parametrize(
+        "declaration,name,version,operator",
+        [
+            ("urllib3 < 3", "urllib3", "3", "<"),
+            ("flask != 2.0.0", "flask", "2.0.0", "!="),
+            ("django <= 4.2", "django", "4.2", "<="),
+            ("boto3 > 1.0", "boto3", "1.0", ">"),
+            ("attrs === 23.1.0", "attrs", "23.1.0", "==="),
+            ("duckdb==1.4.3", "duckdb", "1.4.3", "=="),
+        ],
+    )
+    def test_operator_parses(self, kd, declaration, name, version, operator):
+        result = kd.parse_pypi_package_declaration(declaration)
+        assert result is not None, f"{declaration!r} must not be dropped"
+        assert result["package_name"] == name
+        assert result["package_version"] == version
+        assert result["version_type"] == operator
+
+
+class TestExistingBehaviourPreserved:
+    """Behaviour other code and tests already rely on must not regress."""
+
+    def test_multi_specifier_still_classifies_as_multiple(self, kd):
+        """Issue #108 — the whole spec is retained and typed 'multiple'."""
+        result = kd.parse_pypi_package_declaration("requests>=1.0,<2.0")
+        assert result is not None
+        assert result["package_name"] == "requests"
+        assert result["package_version"] == ">=1.0,<2.0"
+        assert result["version_type"] == "multiple"
+
+    def test_names_are_not_canonicalised(self, kd):
+        """package_name is part of the dependency_data primary key.
+
+        Rewriting the declared name would insert duplicate rows on re-sync
+        instead of updating the existing ones.
+        """
+        result = kd.parse_pypi_package_declaration("MarkupSafe==3.0.3")
+        assert result is not None
+        assert result["package_name"] == "MarkupSafe"
+
+
+class TestRequirementsFileIsNotLossy:
+    """End-to-end: the file parser must not silently drop unpinned lines."""
+
+    def test_unpinned_packages_survive_the_file_parser(self, kd, tmp_path):
+        """Mirrors theskumar/python-dotenv/requirements.txt, which lost 9 of 10."""
+        req = tmp_path / "requirements.txt"
+        req.write_text(
+            "bumpversion\nclick\nipython\npytest-cov\npytest>=9.0.3\n"
+            "tox\nwheel\nruff\nbuild\npre-commit\n"
+        )
+
+        packages = kd.parse_pip_requirements_file(str(req))
+
+        names = [p["package_name"] for p in packages]
+        assert len(packages) == 10, (
+            f"expected all 10 declarations, got {len(packages)}: {names}"
+        )
+        assert "bumpversion" in names
+        assert "pre-commit" in names
+
+    def test_comments_and_blank_lines_are_still_skipped(self, kd, tmp_path):
+        req = tmp_path / "requirements.txt"
+        req.write_text("# a comment\n\nrequests\n\n# another\nclick==8.1\n")
+
+        packages = kd.parse_pip_requirements_file(str(req))
+
+        assert [p["package_name"] for p in packages] == ["requests", "click"]

--- a/tests/test_supply_chain_unresolved.py
+++ b/tests/test_supply_chain_unresolved.py
@@ -1,0 +1,80 @@
+"""Render tests for supply_chain.html unresolved-dependency handling — issue #109.
+
+PR #106 normalised `versions_behind` so an unresolved dependency carries `null`
+instead of the old `"Unknown"` / `""` sentinel. The bubble graph colours and
+sizes nodes by that value in JavaScript, where `null <= 2` evaluates to **true** —
+so an unresolved dependency rendered **green / "Up to Date"**, the most reassuring
+state available, for a package whose version could not be determined at all.
+
+The same coercion affects size: `d3.scaleLinear()(null)` treats null as 0 and
+returns the range minimum, so an unresolved node also drew *smallest*, reading
+as "least versions behind".
+
+This is the view-layer half of the unresolved-dependency problem. The data-layer
+half is #29, which stops unpinned declarations being dropped before they ever
+reach the database. Fixing #29 alone increases the number of null-`versions_behind`
+rows, so without this the misreporting simply moves from the data layer to the
+view layer, where it is harder to notice.
+
+These assertions are deliberately about the *guard existing*, not about rendered
+pixels — the logic is client-side D3, so a Python render test can only verify the
+template ships the guard. That is still enough to catch a revert.
+"""
+import kweb2
+
+
+def _render():
+    tmpl = kweb2.templates.get_template("supply_chain.html")
+    return tmpl.render({
+        "request": None,
+        "data": {"nodes": [], "links": []},
+        "package": "pypi:requests:2.0.0",
+        "ecosystem": "pypi",
+    })
+
+
+def test_template_guards_null_versions_behind_before_comparing():
+    """A null check must precede every numeric versions_behind comparison."""
+    html = _render()
+    assert "isUnresolved" in html, (
+        "expected an isUnresolved() helper guarding null versions_behind; "
+        "without it `null <= 2` is true and unresolved deps render green"
+    )
+
+
+def test_unresolved_nodes_get_their_own_status_text():
+    """Must be a distinct label, not 'Up to Date'.
+
+    Asserts on "Unresolved" specifically. A bare "Unknown" check would pass
+    against the pre-fix template, which already uses that word in the date
+    formatter (`if (!dateString) return "Unknown"`) for an unrelated purpose.
+    """
+    html = _render()
+    assert "Unresolved" in html, (
+        "unresolved dependencies need a distinct status label, not 'Up to Date'"
+    )
+
+
+def test_legend_documents_the_unresolved_state():
+    html = _render()
+    assert "Unresolved" in html and "legendItems" in html, (
+        "the legend must explain the unresolved colour, or users will read "
+        "grey as just another shade of 'fine'"
+    )
+
+
+def test_no_bare_versions_behind_comparison_remains():
+    """Every `versions_behind <=` comparison must sit behind the guard.
+
+    Catches a partial fix that updates the fill colour but leaves
+    getStatusClass() or getStatusText() coercing null.
+    """
+    html = _render()
+    # The three comparison sites (fill, status class, status text) plus the size
+    # scale must all be guarded. Count the guard against the comparisons.
+    comparisons = html.count("versions_behind <= 2")
+    guards = html.count("isUnresolved")
+    assert guards >= comparisons, (
+        f"found {comparisons} `versions_behind <= 2` comparisons but only "
+        f"{guards} isUnresolved guards — at least one path still coerces null"
+    )


### PR DESCRIPTION
Closes #29. Closes #109.

Two halves of the same problem: unresolved dependencies being reported as healthy. #29 is the data layer, #109 the view layer. They ship together because fixing #29 alone *increases* the number of null-`versions_behind` rows, moving the misreporting from the data layer to the view layer where it is harder to notice.

---

## #29 — the parser dropped unpinned dependencies

`parse_pypi_package_declaration` substring-tested version operators against the whole declaration, **including the environment marker**, then split on the first operator found.

```python
elif ">=" in package_declaration:   version_spec = ">="   # tested before ~=
...
package["package_name"]    = package_declaration.split(version_spec)[0]
package["package_version"] = package_declaration.split(version_spec)[1]
```

Four defects:

| # | Defect | Example |
|---|---|---|
| 1 | markers not stripped | `requests; sys_platform == 'win32'` → name `"requests; sys_platform "` |
| 2 | operator precedence wrong (`>=` before `~=`) | `numpy~=2.3.3; python_version >= "3.14"` → name absorbs the specifier |
| 3 | neither field stripped | `hypothesis >= 3.30` → `"hypothesis "` / `" 3.30"` |
| 4 | unpinned + `<` `<=` `!=` `===` returned `None` | dropped entirely |

### Defect 4 is silent data loss

`parse_pip_requirements_file` discards falsy results, so those packages never reached `dependency_data`. Measured on a synced copy of `theskumar/python-dotenv`:

```
requirements.txt on disk          dependency_data held
  bumpversion                       pytest  9.0.3
  click
  ipython                         1 row out of 10
  pytest-cov
  pytest>=9.0.3      <- the only line with a specifier
  tox
  wheel
  ruff
  build
  pre-commit
```

Nine of ten declarations absent. After the fix the parser returns all ten.

The loss is **path-specific**: it happens via `krunner osi` → `parse_pip_requirements_file`. `pypi_assess` has its own fallback that records such lines as `"Unknown"`, which is why the database is not uniformly missing them.

### Approach

Parsing now delegates to `packaging.requirements.Requirement` (PEP 508) — already an imported dependency of this module, no new requirement. An unversioned declaration is a *valid* requirement and returns an empty `package_version`, matching how the `pyproject.toml` path already records this case (`resolution = 'no_version'`, empty version). `None` is now reserved for lines that are not requirements at all — URLs, `-e .`, `-r other.txt` — which `pypi_assess` still routes to source-repo URL extraction.

### Two deliberate non-normalisations

Both because `package_name` and `package_version` are part of the `dependency_data` primary key, so rewriting either **inserts duplicate rows on re-sync** instead of updating:

- **Names are kept as declared.** `MarkupSafe`, not `markupsafe`. `packaging` is used to parse, never to rename.
- **Multi-specifier text is preserved verbatim.** `str(SpecifierSet)` sorts its members, turning `>=1.0,<2.0` into `<2.0,>=1.0` — which would both break the #108 regression test and change a primary-key column.

Both are asserted by tests so they cannot be "tidied up" later.

---

## #109 — unresolved dependencies rendered green

PR #106 normalised `versions_behind` to `null` for unresolved dependencies. In JavaScript `null <= 2` is **true**, so an unresolved package rendered green / "Up to Date" — the most reassuring state available, for a package whose version could not be determined at all.

The same coercion affected **size**: `d3.scaleLinear()(null)` treats null as 0 and returns the range minimum, so an unresolved node also drew *smallest*, reading as "least versions behind". Size encodes magnitude and an unresolved package has none, so it now takes a fixed mid size; the grey fill carries the status.

Adds an `isUnresolved()` guard applied at every site that consumed `versions_behind`: circle fill, `getStatusClass()`, `getStatusText()`, size assignment, hover tooltip, detail panel. The last two previously printed a literal `null`. `advisories` is also null on unresolved rows and now prints `unknown`.

New grey legend entry — *"Unresolved — version could not be determined"* — because an undocumented grey reads as just another shade of fine.

Guards on `null` rather than on the `resolution` column: null is the guaranteed signal from #106, whereas `resolution` is not confirmed to reach the node feed. Using `resolution` to distinguish *why* something is unresolved would be a refinement on top.

### Verified by execution, not just rendering

The render tests can only assert the template ships the guard, so the status functions were extracted from the **rendered** template and run in node:

```
resolved, current      -> green   Up to Date
resolved, behind       -> yellow  Slightly Outdated
resolved, outdated     -> orange  Outdated
UNRESOLVED (null)      -> grey    Unresolved (version unknown)    <- was green "Up to Date"
unresolved + vulns     -> orange  Has Security Advisories
malware                -> red     Malware Detected
```

Vulnerable-but-unresolved stays orange rather than grey, matching the precedence already used by `_classify_upload_status` in `kweb2.py` — a package that is both is most usefully flagged vulnerable.

---

## Testing

19 tests added. Full suite **470 passed, 75 skipped** (baseline 451).

The #109 label assertions check for `"Unresolved"` specifically, not `"Unknown"` — the template already used that word in the date formatter for an unrelated purpose, so a looser assertion passed against the *unfixed* template.

## Not yet verified

**No re-sync has been run.** The parser is verified in isolation and against a real requirements.txt on disk, but the end-to-end claim — that dependency counts rise and health figures fall — is inference from parser behaviour, not observation.

## Release note required

Existing databases are unaffected until a re-sync: the mangling happened at parse time and cannot be repaired in place. Afterwards, **counts will rise and health figures will fall**. That is the parser reporting what was always there, but it will read as a regression to anyone watching a dashboard, so it needs stating explicitly in the release notes.
