### PR TITLE
feat: add Dependencies as the first repo Quick Link

### DIFF
--- a/src/templates/repo_view.html
+++ b/src/templates/repo_view.html
@@ -125,6 +125,12 @@
                     <div class="flex flex-wrap gap-4 text-sm">
                         <span class="text-gray-700">View repo:</span>
                         <a
+                            href="/dependencies/{{ repo_id }}"
+                            class="text-blue-600 hover:text-blue-800 underline"
+                            >Dependencies</a
+                        >
+                        <span class="text-gray-500">|</span>
+                        <a
                             href="/landscape/?repo_id={{ repo_id }}"
                             class="text-blue-600 hover:text-blue-800 underline"
                             >Tech Landscape</a


### PR DESCRIPTION
The repo page links to Tech Landscape, the graph views, collaborators and tenure — but not to `/dependencies/{repo_id}`, despite that route existing and being the natural first question about a repo. Reaching it meant typing the URL by hand.

## Change

One link added to the Quick Links bar, placed first:

```
Dependencies                     /dependencies/{repo_id}     <- new
Tech Landscape                   /landscape/?repo_id=...
Explore the graph                /graph/?repo_id=...
Graph developer contributions    /bubble/{repo_id}
Author / Committer collaborators /collab/{repo_id}
Commit and Tenure statistics     /tenure/{repo_id}
```

Verified by rendering `repo_view.html` — `/dependencies/github.com~pydantic~pydantic` resolves correctly.

No route, query or template logic changes; the `/dependencies/{id}` endpoint already exists.