### PR TITLE
docs(changelog): record the repo-page Dependencies link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 - **`krunner branches -strict`** exits non-zero if any repo errored, for CI and
   cron jobs that need failures to surface without parsing output. The default
   stays exit 0 so existing scripts are unaffected.
+- **Repo page links to its dependencies.** `/repo/{repo_id}` gains a
+  **Dependencies** link, placed first in the Quick Links bar ahead of Tech
+  Landscape. The `/dependencies/{repo_id}` route already existed but nothing
+  linked to it, so reaching a repo's dependency list meant typing the URL.
 
 ### Changed
 - **The AI tags panopticas emits for `CLAUDE.md` and `GEMINI.md` have changed


### PR DESCRIPTION
Follow-up to #140, which merged before this CHANGELOG entry was pushed to the branch — so the entry landed on the branch but outside the PR and never reached `main`.

Adds one bullet to `## Unreleased` → `### Added`:

> **Repo page links to its dependencies.** `/repo/{repo_id}` gains a **Dependencies** link, placed first in the Quick Links bar ahead of Tech Landscape. The `/dependencies/{repo_id}` route already existed but nothing linked to it, so reaching a repo's dependency list meant typing the URL.

Documentation only — no code change. The equivalent entry landed in FoundationX with its paired PR.