### PR TITLE
fix: demote latest rows by file, not by package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,31 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   `developer_stats` update.
 
 ### Fixed
+- **Renamed and removed dependencies stayed flagged as current forever.**
+  `save_dependencies` demoted prior rows keyed on `(_repo_id, file_path,
+  package_name)`, taking the name from the *incoming* record — so the demote
+  only ran for names present in the batch. Two classes of row were left stuck
+  at `latest = 1`. **Renamed packages:** `package_name` is part of the
+  `dependency_data` primary key, so a parser change that derives a different
+  name inserts a new row rather than updating the old one, and a demote keyed
+  on the new name never reaches the predecessor — after the PEP 508 parser
+  above began separating extras, `mkdocstrings[python]` (`package_not_found`)
+  and `mkdocstrings` (`resolved`) were both current for the same file, so a
+  repo reported 17 dependencies where 16 was correct. **Removed dependencies:**
+  a package deleted from a manifest has no incoming record at all, so nothing
+  ever demoted it — delete a package from `requirements.txt`, re-parse, and
+  kospex kept reporting it as a current dependency. This second one predates
+  the parser work. The demote is now keyed on `(_repo_id, file_path)`: a
+  re-parse supersedes everything previously extracted from that manifest,
+  whatever those packages were called.
+
+  This does not grow the table — the demote is an `UPDATE`, never a `DELETE`,
+  and row count is driven by the upsert primary key (chiefly `hash`). Only the
+  `latest` flag changes. Existing stale rows need no migration; they are
+  demoted by the next re-parse of their file. One behaviour change worth
+  knowing: a *partial* parse now demotes packages it failed to re-extract,
+  where previously they were left looking current. `krunner osi` accumulates
+  every file and writes once, so it is not exposed to that.
 - **Unpinned Python dependencies were silently dropped and never reached
   `dependency_data`.** `parse_pypi_package_declaration` substring-tested version
   operators against the whole declaration — *including the environment marker* —

--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -477,10 +477,35 @@ class KospexDependencies:
         package_version); _git_server/_git_owner/_git_repo are derived from
         _repo_id when absent.
 
-        Before inserting, prior rows for each (_repo_id, file_path,
-        package_name) are demoted to latest=0 so re-runs don't accumulate
-        stale "latest" rows; the incoming records are then upserted with
-        latest=1.
+        Before inserting, **all** prior rows for each (_repo_id, file_path)
+        being written are demoted to latest=0; the incoming records are then
+        upserted with latest=1. A re-parse of a manifest supersedes everything
+        previously extracted from it, whatever those packages were called.
+
+        The demote is deliberately keyed on the file rather than on
+        (_repo_id, file_path, package_name). Keying it on the package name
+        meant the demote only ran for names present in the incoming batch,
+        which left two classes of row stuck at latest=1 forever:
+
+        * **Renamed packages.** package_name is part of the primary key, so a
+          parser change that derives a different name inserts a new row instead
+          of updating the old one — and the demote, keyed on the new name,
+          never reached the predecessor. Observed live: `mkdocstrings[python]`
+          (package_not_found) and `mkdocstrings` (resolved) both current for the
+          same file, after the PEP 508 parser began separating extras.
+        * **Removed dependencies.** A package deleted from a manifest has no
+          incoming record at all, so nothing ever demoted it and kospex kept
+          reporting it as a current dependency.
+
+        Trade-off: a partial parse now demotes the packages it failed to
+        re-extract. "Not found this time" is the honest reading, and the rows
+        stay queryable at latest=0 — but a truncated run marks more rows stale
+        than it replaces. `krunner osi` accumulates every file and calls this
+        once, so it is not exposed to that.
+
+        Note this only changes which rows are *flagged* current. Row growth is
+        driven by the upsert primary key — chiefly `hash` — and is unaffected;
+        the demote is an UPDATE, never a DELETE.
 
         source: value for the [source] column identifying the writing tool.
 
@@ -489,17 +514,19 @@ class KospexDependencies:
         if not records:
             return 0
 
-        # Demote prior "latest" rows for each (_repo_id, file_path,
-        # package_name) we are about to (re)write.
+        # Demote every prior "latest" row for each (_repo_id, file_path) we are
+        # about to rewrite — not just the package names in this batch. A
+        # re-parse supersedes the whole file; keying this on package_name left
+        # renamed and removed packages stuck at latest=1. See the docstring.
         demote_keys = {
-            (r.get("_repo_id"), r.get("file_path"), r.get("package_name"))
+            (r.get("_repo_id"), r.get("file_path"))
             for r in records
         }
-        for repo_id, file_path, package_name in demote_keys:
+        for repo_id, file_path in demote_keys:
             self.kospex_db.execute(
                 f"UPDATE {KospexSchema.TBL_DEPENDENCY_DATA} SET latest = 0 "
-                "WHERE _repo_id = ? AND file_path = ? AND package_name = ?",
-                [repo_id, file_path, package_name],
+                "WHERE _repo_id = ? AND file_path = ?",
+                [repo_id, file_path],
             )
 
         cleaned = []

--- a/tests/test_dependencies_save.py
+++ b/tests/test_dependencies_save.py
@@ -132,3 +132,133 @@ def test_save_dependencies_persists_resolution():
     }], source="krunner osi")
     row = next(db.query("SELECT resolution, versions_behind FROM dependency_data"))
     assert row["resolution"] == "unresolved_spec" and row["versions_behind"] is None
+
+
+def _existing_row(db, **overrides):
+    """Insert a prior latest=1 row, defaults matching a typical krunner osi write."""
+    row = {
+        "_repo_id": "github.com~kospex~kospex",
+        "hash": "abc123",
+        "file_path": "requirements.txt",
+        "package_type": "pypi",
+        "package_name": "requests",
+        "package_version": "2.31.0",
+        "latest": 1,
+        "source": "krunner osi",
+    }
+    row.update(overrides)
+    db[KospexSchema.TBL_DEPENDENCY_DATA].insert(row, pk=_PK, replace=True)
+    return row
+
+
+def test_renamed_package_does_not_orphan_its_predecessor():
+    """A parser change that derives a different name must not leave two latest rows.
+
+    package_name is part of the primary key, so a re-parse that derives a new
+    name inserts a new row rather than updating the old one. Demoting by
+    (_repo_id, file_path, package_name) keys the demote on the very thing that
+    changed, so the old row keeps latest=1 forever.
+
+    Observed live: `mkdocstrings[python]` (package_not_found) and `mkdocstrings`
+    (resolved) both sat at latest=1 for the same file after the PEP 508 parser
+    began separating extras from the name.
+    """
+    db = _make_db()
+    kdeps = KospexDependencies(kospex_db=db)
+
+    _existing_row(db, package_name="mkdocstrings[python]", package_version="0.24.0",
+                  file_path="requirements-docs.txt")
+
+    # Re-parse derives the name without the extras.
+    kdeps.save_dependencies([{
+        "_repo_id": "github.com~kospex~kospex",
+        "hash": "abc123",
+        "file_path": "requirements-docs.txt",
+        "package_type": "pypi",
+        "package_name": "mkdocstrings",
+        "package_version": "0.24.0",
+    }], source="krunner osi")
+
+    current = [r["package_name"] for r in db[KospexSchema.TBL_DEPENDENCY_DATA].rows
+               if r["latest"] == 1]
+    assert current == ["mkdocstrings"], (
+        f"expected only the re-parsed name to be current, got {current} — "
+        "the predecessor was not demoted"
+    )
+
+
+def test_dependency_removed_from_a_manifest_is_demoted():
+    """A package deleted from a manifest must stop being reported as current.
+
+    The per-package demote only ran for packages present in the incoming batch,
+    so a dependency removed from the file had no incoming record, was never
+    demoted, and stayed latest=1 indefinitely.
+    """
+    db = _make_db()
+    kdeps = KospexDependencies(kospex_db=db)
+
+    _existing_row(db, package_name="click", package_version="8.1.0")
+    _existing_row(db, package_name="requests", package_version="2.31.0")
+
+    # `click` has since been deleted from requirements.txt; only requests remains.
+    kdeps.save_dependencies([{
+        "_repo_id": "github.com~kospex~kospex",
+        "hash": "abc123",
+        "file_path": "requirements.txt",
+        "package_type": "pypi",
+        "package_name": "requests",
+        "package_version": "2.31.0",
+    }], source="krunner osi")
+
+    rows = {r["package_name"]: r["latest"] for r in db[KospexSchema.TBL_DEPENDENCY_DATA].rows}
+    assert rows["requests"] == 1
+    assert rows["click"] == 0, "a dependency no longer in the manifest must not stay current"
+
+
+def test_demote_is_scoped_to_the_files_being_written():
+    """Demoting by file must not touch other files in the same repo."""
+    db = _make_db()
+    kdeps = KospexDependencies(kospex_db=db)
+
+    _existing_row(db, file_path="requirements.txt", package_name="requests")
+    _existing_row(db, file_path="requirements-dev.txt", package_name="pytest",
+                  package_version="8.0.0")
+
+    kdeps.save_dependencies([{
+        "_repo_id": "github.com~kospex~kospex",
+        "hash": "abc123",
+        "file_path": "requirements.txt",
+        "package_type": "pypi",
+        "package_name": "requests",
+        "package_version": "2.32.0",
+    }], source="krunner osi")
+
+    latest = {(r["file_path"], r["package_name"], r["package_version"]): r["latest"]
+              for r in db[KospexSchema.TBL_DEPENDENCY_DATA].rows}
+    # untouched file keeps its current row
+    assert latest[("requirements-dev.txt", "pytest", "8.0.0")] == 1
+    # rewritten file: old version demoted, new version current
+    assert latest[("requirements.txt", "requests", "2.31.0")] == 0
+    assert latest[("requirements.txt", "requests", "2.32.0")] == 1
+
+
+def test_demote_is_scoped_to_the_repo_being_written():
+    """Another repo with the same file path must be unaffected."""
+    db = _make_db()
+    kdeps = KospexDependencies(kospex_db=db)
+
+    _existing_row(db, _repo_id="github.com~other~repo", package_name="requests")
+
+    kdeps.save_dependencies([{
+        "_repo_id": "github.com~kospex~kospex",
+        "hash": "abc123",
+        "file_path": "requirements.txt",
+        "package_type": "pypi",
+        "package_name": "requests",
+        "package_version": "2.32.0",
+    }], source="krunner osi")
+
+    other = [r for r in db[KospexSchema.TBL_DEPENDENCY_DATA].rows
+             if r["_repo_id"] == "github.com~other~repo"]
+    assert len(other) == 1
+    assert other[0]["latest"] == 1, "another repo's rows must not be demoted"


### PR DESCRIPTION
Two classes of `dependency_data` row could stay flagged `latest = 1` forever.

`save_dependencies` demoted prior rows keyed on `(_repo_id, file_path, package_name)`, taking the name from the **incoming** record — so the demote only ran for names present in the batch.

## Bug 1 — renamed packages

`package_name` is part of the primary key, so a parser change that derives a different name **inserts** a new row rather than updating the old one. The demote, keyed on the new name, never reaches the predecessor.

Observed live after the PEP 508 parser (#29) began separating extras from the name:

```
mkdocstrings          0.24.0  resolved           latest=1   <- new, correct
mkdocstrings[python]  0.24.0  package_not_found  latest=1   <- stale, orphaned
```

The repo reported **17** dependencies where 16 was correct. Four rows estate-wide carry extras and are affected.

There is a genuine improvement hiding in that pair, incidentally: deps.dev cannot resolve an extras-qualified name, so `mkdocstrings[python]` was `package_not_found` purely as an artefact of the old parser. Separating the extras makes it resolve.

## Bug 2 — removed dependencies

**This one predates the parser work.** A package deleted from a manifest has no incoming record at all, so nothing ever demoted it. Delete a package from `requirements.txt`, re-parse, and kospex keeps reporting it as a current dependency indefinitely.

## Fix

Demote by `(_repo_id, file_path)`. A re-parse supersedes everything previously extracted from that manifest, whatever those packages were called.

## This does not grow the table

Worth stating explicitly, since "demote more rows" sounds like it should:

- the demote is an `UPDATE`, never a `DELETE`
- row count is driven entirely by the upsert primary key — chiefly `hash`, which is why 8,480 rows currently back 6,210 current ones
- INSERT behaviour is byte-identical before and after; only the `latest` flag changes

## No migration needed

Existing stale rows self-heal on the next re-parse, since the demote now reaches every prior row for the file. All four affected rows sit in specific `(repo, file)` pairs:

```
httpx          requirements.txt                              coverage[toml]
flask          examples/celery/requirements.txt              celery[redis]
pytest         testing/plugins_integration/requirements.txt  anyio[trio]
python-dotenv  requirements-docs.txt                         mkdocstrings[python]
```

## Trade-off

A **partial** parse now demotes packages it failed to re-extract. "Not found this time" is the honest reading and the rows stay queryable at `latest = 0`, but a truncated run marks more rows stale than it replaces — where previously they were left looking current. `krunner osi` accumulates every file and calls `save_dependencies` once, so it is not exposed to this.

## Testing

4 tests added — one per bug, plus guards that the wider demote stays scoped to the files and the repo being written (it must not touch a sibling manifest or another repo with the same path). Both bug tests were watched failing first.

Full suite **541 passed, 8 skipped**.

Verified end-to-end against a live database: the affected repo now reports 16, consistent in both kweb and the downstream UI.