### PR TITLE
Fix list-repos scope resolution and refresh the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,21 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   `developer_stats` update.
 
 ### Fixed
+- **`kospex list-repos -db -repo_id` returned no rows.** `list-repos` defines
+  `-repo_id` as an `is_flag` option meaning "add the Repo ID column to the
+  output", but the whole kwargs dict is forwarded to
+  `KospexData.set_params_by_id()`, which read `repo_id=True` as a scope value
+  and emitted `WHERE _repo_id = 1` — matching nothing. The same dict also
+  carries display-only keys such as `db=True`, which defeated the
+  `any(id_params.values())` all-scope test and sent an unscoped call down an
+  error branch that printed `ERROR: can't identify {...}` to stdout while
+  correctly applying no filter. Scope resolution now considers only `repo_id`,
+  `org_key` and `server`, and only when they hold a non-empty string; anything
+  else means "all scope". Also removed a leftover `print(kwargs)` debug
+  statement from `Kospex.list_repos()`, so `-db` output is no longer preceded
+  by a raw params dict. Row counts for `-db`, `-db -repo_id` and
+  `-db -server SERVER` now match the `repos` table exactly.
+
 - **Renamed and removed dependencies stayed flagged as current forever.**
   `save_dependencies` demoted prior rows keyed on `(_repo_id, file_path,
   package_name)`, taking the name from the *incoming* record — so the demote

--- a/README.md
+++ b/README.md
@@ -1,142 +1,233 @@
 # kospex
 
-Kospex is a CLI and Web application gain insights into your developers, opensource maintenacne and technology landscape.
+[![PyPI version](https://img.shields.io/pypi/v/kospex.svg)](https://pypi.org/project/kospex/)
+[![Python](https://img.shields.io/pypi/pyversions/kospex.svg)](https://pypi.org/project/kospex/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-docs.kospex.io-blue)](https://docs.kospex.io/)
 
-Inspired by the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite) to model data from git repositories.
+Kospex maps the **knowledge**, **technology** and **maintenance risk** hiding in your git repositories.
 
-## Step 1: Installation, setup and usage
+It answers questions that are surprisingly hard to answer at scale:
 
-kospex is currently a python module with commands. It works by analysing cloned repositories on the filesystem.
+- *Who still knows this code?*
+- *What are we actually built on?*
+- *What's quietly going stale?*
 
-**Optional but strongely recommended** - use a python virtual env.
+Kospex inspects cloned repositories on disk and aggregates everything into a single
+queryable database, so you can ask those questions across one repo or thousands.
+There are two ways to use it: a **CLI** for scanning, querying and automation, and a
+**Web UI** (`kweb`) for exploring the data interactively.
 
-Installing using pip:
+Inspired by the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite),
+whose database structure we use to model data from git repositories.
 
-> pip install kospex
+## Quickstart
 
-For complexity and file type analysis, kospex uses the scc binary.
-It is optional, but enables much better file type guessing and provide complexity metrics.
-Follow the instructions for installing [scc](https://github.com/boyter/scc)
+Requires Python 3.12+. A virtual environment is optional but strongly recommended.
 
-### Step 2: Initial kospex setup
+```bash
+# 1. Install
+pip install kospex
 
-kospex uses a git repositoriy layout for cloning repos to disk.
+# 2. Set up ~/kospex (config, database, logs) and ~/code (cloned repos)
+kospex init --create --verbose
 
-The following structure is used \
-/BASE/GIT_SERVER/ORG/REPO
+# 3. Clone a repo — this clones into ~/code/GIT_SERVER/ORG/REPO and syncs it
+kgit clone https://github.com/mergestat/mergestat-lite
 
-If you are ok to use the ~/code directory for cloned repos, then run:
-> kospex init --default
+# 4. Ask some questions
+kospex summary
+kospex developers -days 90
+kospex tech-landscape -metadata
 
-See section "Git code layout for running analysis" below for more details.
+# 5. Explore it all in the browser at http://127.0.0.1:8000
+kweb
+```
 
+Already have repositories cloned somewhere? Sync the lot in one go:
 
-### Step 3: sync some data and play with some commands
+```bash
+kospex sync-directory /path/to/your/repos
+```
 
-For an existing repo on disk:
-> kospex sync [GIT_REPO]
+For complexity metrics and much better file type detection, install the
+[scc](https://github.com/boyter/scc) binary (`brew install scc`). It's optional, but recommended.
 
-You can also use the _kgit_ command to clone and sync a repo you have access to
+Full walkthrough: [Getting started](https://docs.kospex.io/getting-started).
 
-> kgit clone https://github.com/mergestat/mergestat-lite
+## What kospex gives you
 
-The above command will clone into the KOSPEX_CODE/GIT_SERVER/ORG/REPO structure
+### Knowledge mapping
 
-Some commands to try:
+Who knows what, and whether they're still around.
 
-> kospex developers -repo [GIT_REPO]
->
-> kospex tech-landscape -metadata
+- Active developers (e.g. who's committed in the last 90 days) vs. historical contributors
+- Contribution depth at repo, directory and file level
+- Derived code ownership — top and most-recent committers who still work here
+- Key person and offboarding risk — repos and files with a single active committer
 
+### Technology identification
 
-## Git code layout for running analysis
+More than just languages — kospex identifies the whole toolchain from filenames, paths and content:
 
-One option, if you're inspecting code on your own laptop (or virtual machine), is to use use your home directory.
+- **Languages** and file types, with complexity metrics via `scc`
+- **Infrastructure as code** — Docker, Terraform and friends
+- **Package managers and build tools** — npm/yarn/pnpm, pip/uv, Maven, Gradle, Go modules, RubyGems, Composer, Cargo, NuGet
+- **CI/CD pipelines** — GitHub Actions, GitLab CI, Jenkins, Azure DevOps, Bitbucket Pipelines, CircleCI, Buildkite, Travis
+- **Linters and config** — eslint, SQLFluff and other quality tooling
 
-~/kospex/ \
-We'll place config files and the kospex DB (Sqlite3) in here for sync'ed data \
-~/code/ \
-This should be your GIT_DATA_DIRECTORY with a structure like \
-GIT_SERVER/ORG/REPO \
- \
-For example, in your ~/code it might look like: \
-github.com/kospex/kospex \
-github.com/mergestat/mergestat-lite
+The result is a technology landscape you can compare over time — what you build with
+now, versus twelve months ago.
 
-This way we have a nice deterministic way of separating different orgs, potentially different instances (e.g. you have an on premise bitbucket and use GitHub.com) as well.
+### Open source libraries
 
-## Key Use Cases and features
+- Declared dependencies extracted from manifest and lock files across supported ecosystems
+- How far behind the current release each dependency is
+- Security advisory counts, sourced from [deps.dev](https://deps.dev)
 
- - Identify technology landscape
- - Identify active developers (e.g. who's had their code committer in the last 90 days)
- - Identify key person or offboarding risk
- - Identify potential complexity challenges (or conceptual integrity concerns)
- - Aggregate repo metadata into a single database for easier and faster querying
+### Maintenance indicators
 
-## Queries to try
+Signals that code needs attention — or an owner:
 
-### sync a repo
+- **Orphaned repos** — no active committer still contributing
+- **Aging and unmaintained code** — based on last commit activity
+- **Out of date libraries** — dependencies well behind current, or with known advisories
+- **Complexity hotspots** — files that change often and are hard to change
 
-> kospex sync PATH/TO/GIT_REPO
+Longer write-ups are in [use cases](https://docs.kospex.io/use-cases).
 
-_Most functions require the data to be synced._
+## Commands you'll use most
 
-### Show recent developers who've committed in X days
+Most commands need data synced into the kospex DB first.
 
-List the active developers (90 days) in the given repo (sync required)
-> kospex developers -repo PATH/TO/REPO
+| Command | What it does |
+| ------- | ------------ |
+| `kospex summary` | Overview of every synced repo — developers, activity and status |
+| `kospex developers -days 90` | Developers who've committed recently |
+| `kospex tech-landscape -metadata` | Technology stack across everything you've synced |
+| `kospex stats REPO_ID` | Developer stats and key person analysis for one repo |
+| `kospex key-person PATH/TO/REPO` | Top all-time and top active committers |
+| `kospex orphans` | Repos with no still-active committers (experimental) |
+| `kospex hotspot -repo PATH/TO/REPO` | Files that change often and are complex |
+| `kospex deps -repo PATH/TO/REPO` | Find dependency manifest and lock files |
+| `kospex sca` | Lightweight software composition analysis |
+| `kospex list-repos -db` | Everything synced into the database (add `-repo_id` for the ID column) |
+| `kweb` | Start the Web UI on http://127.0.0.1:8000 |
 
-List the developers in the given repo_id (sync'ed data in the kospex DB)
-> kospex developers -repo_id=github.com&tilde;ORG&tilde;REPO
+Most query commands accept `-repo PATH/TO/REPO` for a repo on disk, or `-repo_id` /
+`-org_key` / `-server` to query synced data. For example:
 
-use -days NUM for seen in the last # of days (e.g. 90 or 365)
+```bash
+kospex developers -repo_id github.com~kospex~kospex
+kospex tech-landscape -repo_id github.com~kospex~kospex
+kospex developers -server github.com -days 365
+```
 
-### Identify technology landscape
+Run `kospex COMMAND --help` for the switches on any command, or see the full
+[command reference](https://docs.kospex.io/commands).
 
-List the overall tech stack, based on file extension, for all sync'ed repos
-> kospex tech-landscape
+### Keeping data fresh
 
-List the overall tech stack for all sync'ed repos (using scc)
-> kospex tech-landscape -metadata
+```bash
+kgit pull --all                  # git pull + re-sync every known clone
+kgit pull --check --all          # offline staleness report, no network
+kgit pull --org github.com~myorg # or scope to one org, server or repo_id
+kospex sync-metadata -repo PATH/TO/REPO
+```
 
-List the overall tech stack for a repo (using scc)
-> kospex tech-landscape -repo PATH/TO/REPO
+Syncing a repo does **not** refresh its dependencies — see
+[Refreshing data](https://docs.kospex.io/refreshing-data) for which command updates which table.
 
-List the tech stack in the given repo_id (sync'ed data in the kospex DB)
-> kospex tech-landscape -repo_id=github.com&tilde;ORG&tilde;REPO
+## How data is organised
+
+Kospex uses a `GIT_SERVER/ORG/REPO` directory layout for cloned repos:
+
+| Directory | Purpose |
+| --------- | ------- |
+| `~/kospex/` | Config files, the kospex DB (SQLite3) and logs |
+| `~/code/` | Cloned repositories, in a `GIT_SERVER/ORG/REPO` structure |
+
+For example:
+
+```
+~/code/
+  github.com/
+    kospex/kospex
+    mergestat/mergestat-lite
+  bitbucket.org/
+    myorg/myrepo
+```
+
+This gives a deterministic way of separating orgs, and different git instances as well
+(e.g. an on-premise Bitbucket alongside GitHub.com). Override the defaults with the
+`KOSPEX_HOME` and `KOSPEX_CODE` environment variables.
+
+Most tables have a `_repo_id` column in the format `GIT_SERVER~OWNER~REPO`, so
+`https://github.com/kospex/kospex` becomes `github.com~kospex~kospex`. Most queries use
+`author_email` from git to mean "a developer".
+
+### Describing aging "things"
+
+Many reports describe something as active, aging, stale or unmaintained. That's a simple
+calculation from a given date, using these default rules:
+
+| Description  | Rule |
+| ------------ | ---- |
+| Active       | < 90 days |
+| Aging        | > 90 and < 180 days |
+| Stale        | > 180 and < 365 days |
+| Unmaintained | > 365 days |
+
+It's applied to the last commit in a repo, the last update of a package manager file, or
+the release date of a library you depend on. Something labelled "unmaintained" may well be
+feature complete — but where there are external dependencies, code usually needs a change
+a couple of times a year.
 
 ## Design principles
 
 - Precompute data where possible and useful
-- Flatten tables, data warehouse style, to enabled easier querying and slicing by git server, owner and repo
-- Be as agnostic to the git provider (i.e. GitHub, BitBucket, GitLab) for base use cases
+- Flatten tables, data warehouse style, to enable easier querying and slicing by git server, owner and repo
+- Be as agnostic to the git provider (GitHub, Bitbucket, GitLab) as possible for base use cases
 - Be mindful that "there is no perfect", only indicators
 - Separate cloning and pull updates from the analysis
 
-## Roadmap
+## Documentation
 
-- Build out automated functional and regressions testing (Currently manual)
-- Build the ability to identify key person or offboarding risk
-- Improve use case documentation
-- Provide a mechanism to better map author_emails to users
+- [Getting started](https://docs.kospex.io/getting-started) — installation, authentication and your first sync
+- [Commands](https://docs.kospex.io/commands) — the full `kospex`, `kgit`, `kweb` and `krunner` reference
+- [Web UI guide](https://docs.kospex.io/kweb/) — what each view shows you
+- [Use cases](https://docs.kospex.io/use-cases) — the longer write-ups
+- [Refreshing data](https://docs.kospex.io/refreshing-data) — which command refreshes which table
+- [Troubleshooting](https://docs.kospex.io/troubleshooting)
+- [CHANGELOG](CHANGELOG.md)
 
-## Data extractions and assumptions
+## Contributing
 
-Most tables have a column, _repo_id, in the format of GIT_SERVER&tilde;OWNER&tilde;REPO
-So for the repository https://github.com/kospex/kospex the _repo_id would be _github.com&tilde;kospex&tilde;kospex_
+Bug reports and pull requests are welcome via
+[GitHub issues](https://github.com/kospex/kospex/issues).
 
-Most queries use author_email from git to mean a "developer".
+To work on kospex, clone it and install in editable mode. The `[test]` extra adds
+`pytest` and `httpx`, which the test suite needs:
 
-## How do I develop and improve kospex?
+```bash
+git clone https://github.com/kospex/kospex
+cd kospex
+pip install -e ".[test]"
+pytest
+```
 
-The easiest way to do development on the kospex repo is to clone kospex and run in "dev mode" using the following commands:
-> git clone https://github.com/kospex/kospex
-> cd kospex
-> pip install -e .
+Quote the extra (`".[test]"`) — zsh treats bare brackets as a glob. If you only want to
+run kospex rather than develop it, `pip install -e .` is enough.
+
+Frontend assets are built with `npm install && npm run build`.
 
 ## What is a kospex?
 
 We're aiming to [k]now your c[o]de by in[spe]cting the haruspe[x].
-From Wikipedia, _The Latin terms haruspex and haruspicina are from an archaic word, hīra = "entrails, intestines"_
+From Wikipedia, _The Latin terms haruspex and haruspicina are from an archaic word,
+hīra = "entrails, intestines"_ — so yes, we do look at the "guts of your code" to
+understand your applications, technology landscape (sprawl?) and developers.
 
-So we're going to help look at the "guts of your code" to gain an understanding of the applications, technology landscape (sprawl?) and developers.
+## License
+
+[MIT](LICENSE) © Peter Freiberg

--- a/README.short.md
+++ b/README.short.md
@@ -1,14 +1,22 @@
 # kospex
 
-Kospex is a CLI and Web application gain insights into your developers, opensource maintenacne and technology landscape.
+Kospex maps the **knowledge**, **technology** and **maintenance risk** hiding in your git repositories.
 
-Inspired by the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite) to model data from git repositories.
+It answers questions that are surprisingly hard to answer at scale: *who still knows this
+code? what are we actually built on? what's quietly going stale?*
 
-For details on changes, see  the [changelog](https://github.com/kospex/kospex/blob/main/CHANGELOG.md)
+Kospex inspects cloned repositories on disk and aggregates everything into a single
+queryable database. There are two ways to use it: a **CLI** for scanning, querying and
+automation, and a **Web UI** (`kweb`) for exploring the data interactively.
+
+Inspired by the excellent [Mergestat lite](https://github.com/mergestat/mergestat-lite),
+whose database structure we use to model data from git repositories.
+
+For details on changes, see the [changelog](https://github.com/kospex/kospex/blob/main/CHANGELOG.md).
 
 ## Installation, setup and usage
 
-See the official [installation documentation](https://kospex.io/getting-started)
+See the official [installation documentation](https://docs.kospex.io/getting-started).
 
 ## What is a kospex?
 

--- a/docs/branch-aware-sync.md
+++ b/docs/branch-aware-sync.md
@@ -17,7 +17,7 @@ inventory:
 ```
 # per repo
 git checkout development
-kospex sync .
+kospex sync-directory .
 
 # once every repo is on development and synced
 krunner osi -all

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,8 +82,12 @@ kospex uses a git repository layout for cloning repos to disk, with the followin
 If you're happy to use the `~/code` directory for cloned repos, run:
 
 ```bash
-kospex init --default
+kospex init --create --verbose
 ```
+
+`--create` creates the missing directories (`~/kospex` and `~/code`, or `KOSPEX_CODE`),
+and `--verbose` shows you what it did. To check an existing setup without changing
+anything, use `kospex init --validate`.
 
 See [Git code layout for running analysis](#git-code-layout-for-running-analysis) below for more details.
 

--- a/docs/kospex.md
+++ b/docs/kospex.md
@@ -42,23 +42,34 @@ The output will be a table with the following columns:
 - `source_repo` — the git URL for this package if known
 - `authors` — the number of authors, if we've synced the source_repo to the kospex DB
 
-## sync
+## sync-directory
 
-The sync command takes all the commit history and adds it to the kospex database.
+The sync-directory command finds every git repo in the given directory (including the
+directory itself, if it's a repo) takes all the commit history and adds it to the kospex
+database.
 
 ```bash
-kospex sync [DIRECTORY]
+kospex sync-directory [DIRECTORY]
 ```
 
 Most likely, you'll cd to a repo and then run the following command:
 
 ```bash
-kospex sync .
+kospex sync-directory .
+```
+
+Or sync everything you've cloned in one go:
+
+```bash
+kospex sync-directory ~/code
 ```
 
 **Parameters**
 
-- `--no-scc` — skip scc analysis.
+- `-force` — sync repos already synced from another directory, repointing them.
+
+To clone and sync in a single step, use [`kgit clone`](kgit). To refresh clones kospex
+already knows about, use `kgit pull`.
 
 ## orphans
 

--- a/docs/web-endpoint-testing.md
+++ b/docs/web-endpoint-testing.md
@@ -163,12 +163,11 @@ For optimal test coverage, your kospex database should contain:
 # Initialize kospex
 kospex init --create
 
-# Sync a test repository  
+# Sync a test repository (kgit clone syncs by default)
 kgit clone https://github.com/kospex/kospex
-kospex sync ~/code/github.com/kospex/kospex
 
 # Or sync any existing repository
-kospex sync /path/to/your/repo
+kospex sync-directory /path/to/your/repo
 ```
 
 ## Troubleshooting

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -835,7 +835,6 @@ class Kospex:
             #     params.append(server)
 
             # results = self.kospex_db.query(sql, params)
-            print(kwargs)
             results = self.kospex_query.get_repos(**kwargs)
 
             for row in results:

--- a/src/kospex_query.py
+++ b/src/kospex_query.py
@@ -2626,6 +2626,12 @@ class KospexData:
 
         If request_id is provided, it takes precedence and is parsed first.
         Falls back to id_params dict if request_id is not provided.
+
+        Callers often pass their full kwargs, which can include non-scope keys
+        (display flags like 'db', filters like 'email'). Only the scope keys below
+        are considered, and only when they hold a non-empty string - CLI flags such
+        as list-repos' -repo_id are booleans and must not be read as a repo id.
+        No recognised scope means "all scope".
         """
         # If request_id string is provided, parse it to get params
         if request_id:
@@ -2636,17 +2642,20 @@ class KospexData:
         if not id_params:
             return
 
-        if repo_id := id_params.get("repo_id"):
+        scope = {
+            key: value
+            for key, value in id_params.items()
+            if key in ("repo_id", "org_key", "server")
+            and isinstance(value, str)
+            and value
+        }
+
+        if repo_id := scope.get("repo_id"):
             self.where("_repo_id", "=", repo_id)
-        elif org_key := id_params.get("org_key"):
+        elif org_key := scope.get("org_key"):
             self.where_org_key(org_key)
-        elif server := id_params.get("server"):
+        elif server := scope.get("server"):
             self.where("_git_server", "=", server)
-        elif not any(id_params.values()):
-            # All keys present but values are None/empty → treat as "all scope"
-            return
-        else:
-            print(f"ERROR: can't identify {id_params}")
 
     def group_name_where_subselect(self, group_name):
         """Add a subselect where clause to the query"""

--- a/tests/test_set_params_by_id_scope.py
+++ b/tests/test_set_params_by_id_scope.py
@@ -1,0 +1,82 @@
+"""Tests for scope resolution in KospexData.set_params_by_id().
+
+Callers routinely pass their whole kwargs dict, which mixes scope keys
+(repo_id / org_key / server) with unrelated ones. Two of those unrelated keys
+used to break the query:
+
+- `list-repos` defines `-repo_id` as an is_flag option meaning "add the Repo ID
+  column to the output". Passing the flag put `repo_id=True` in the dict, which
+  was read as a repo id and emitted `WHERE _repo_id = 1` - matching nothing, so
+  `kospex list-repos -db -repo_id` returned zero rows.
+- A display-only key such as `db=True` made the old `any(id_params.values())`
+  all-scope test false, so an unscoped call fell through to an error branch that
+  printed `ERROR: can't identify {...}` to stdout while still (correctly)
+  applying no filter.
+
+Only non-empty *string* scope keys count. Anything else means "all scope".
+"""
+import pytest
+from sqlite_utils import Database
+
+from kospex_query import KospexData
+
+
+def new_kospex_data():
+    """KospexData needs a DB handle; scope resolution never touches it."""
+    return KospexData(kospex_db=Database(memory=True))
+
+
+def where_clauses(**id_params):
+    """Resolve id_params to the SQL where clauses it produces."""
+    kd = new_kospex_data()
+    kd.set_params_by_id(id_params or None)
+    return kd.where_clause
+
+
+def test_string_repo_id_scopes_the_query():
+    clauses = where_clauses(repo_id="github.com~kospex~kospex")
+    assert len(clauses) == 1
+    assert "_repo_id" in clauses[0]
+
+
+def test_org_key_and_server_still_scope():
+    assert where_clauses(org_key="github.com~kospex")
+    assert any("_git_server" in c for c in where_clauses(server="github.com"))
+
+
+def test_boolean_repo_id_flag_is_not_treated_as_a_repo_id():
+    """The regression: -repo_id is a display flag, not a scope value."""
+    assert where_clauses(db=True, repo_id=True, server=None, email=None) == []
+
+
+def test_false_repo_id_flag_is_not_a_scope():
+    assert where_clauses(db=True, repo_id=False, server=None, email=None) == []
+
+
+def test_display_only_keys_mean_all_scope_not_an_error(capsys):
+    clauses = where_clauses(db=True, repo_id=False, server=None, email=None)
+    assert clauses == []
+    assert "can't identify" not in capsys.readouterr().out
+
+
+def test_scope_still_applies_alongside_display_flags():
+    clauses = where_clauses(db=True, repo_id=True, server="github.com", email=None)
+    assert len(clauses) == 1
+    assert "_git_server" in clauses[0]
+
+
+def test_empty_string_scope_is_ignored():
+    assert where_clauses(repo_id="", org_key="", server="") == []
+
+
+def test_no_params_is_all_scope():
+    assert where_clauses() == []
+
+
+@pytest.mark.parametrize("unknown", [{"author_email": "dev@example.com"}, {"days": 90}])
+def test_unrecognised_keys_are_all_scope_without_error(unknown, capsys):
+    """get_id_params() can return author_email; it is not a repos-table scope."""
+    kd = new_kospex_data()
+    kd.set_params_by_id(unknown)
+    assert kd.where_clause == []
+    assert "can't identify" not in capsys.readouterr().out


### PR DESCRIPTION
Two independent pieces of work: a query-scoping bug fix, and a README/docs refresh that removes commands which no longer exist. Commits are separated accordingly, code first — the docs commit restores `kospex list-repos -db` to the README command table, which only works after the fix.

## `fix:` ignore non-scope kwargs in `set_params_by_id`

`list-repos` declares `-repo_id` as an `is_flag` option meaning *"add the Repo ID column to the output"*, but forwards its whole kwargs dict to `KospexData.set_params_by_id()`. That read `repo_id=True` as a **scope value** and emitted `WHERE _repo_id = 1` — so `kospex list-repos -db -repo_id` matched nothing and returned zero rows.

The same dict carries display-only keys such as `db=True`, which defeated the `any(id_params.values())` all-scope test and sent an unscoped call down an error branch printing `ERROR: can't identify {...}` to stdout, while still correctly applying no filter.

Scope resolution now considers only `repo_id`, `org_key` and `server`, and only when they hold a non-empty **string**. Anything else means all scope, which also drops the bogus error branch. Also removes a leftover `print(kwargs)` debug statement from `Kospex.list_repos()`.

### Verification

Row counts against the `repos` table, all with zero stray output:

| Invocation | Rows | Expected |
| --- | --- | --- |
| `-db` | 105 | 105 |
| `-db -repo_id` | 105 (was **0**) | 105 |
| `-db -server github.com` | 105 | 105 |
| `-db -server bitbucket.org` | 0 | 0 |

`tests/test_web_endpoints.py` is entirely skipped and three of the four `set_params_by_id` callers are web paths, so I exercised them directly across every scope shape rather than relying on the suite — `repos2` and `get_activity_stats` both scope unchanged (none → 105 repos, `server` → 105, `org_key` → 2, `repo_id` → 1); `get_orphans(None)` returns 105 as before.

10 new tests in `tests/test_set_params_by_id_scope.py`. Confirmed they are genuine regression tests by temporarily reverting the fix: **5 fail on the old code**, the other 5 pass both ways and guard that valid scoping still works. Full suite 484 passed, 75 skipped.

One behaviour note: `get_id_params()` can return an `author_email` key, which is not a repos-table scope. Previously that printed the error and applied no filter; now it applies no filter silently. Same query result.

## `docs:` refresh README and fix commands that no longer exist

The README documented two commands that **error out**:

- `kospex sync` — commented out in `kospex_cli.py`, so the quickstart's core happy path did not run
- `kospex init --default` — has never matched the real flags (`--create` / `--verbose` / `--validate`)

`README.md` is rewritten around the current product. The Web UI (`kweb`) was absent despite the tagline naming it, as were dependencies/SCA and the maintenance indicators. Adds badges, a verified fenced quickstart, a command table, the data-refresh commands, the aging model, docs links and a contributing section. Blockquoted commands become fenced blocks, and the `&tilde;` entities become literal `~` — they rendered as U+02DC and would never match a repo_id if copy-pasted.

Contributing now installs the `[test]` extra: `pytest` and `httpx` live there, so `pip install -e .` followed by `pytest` failed for a new contributor.

The same broken commands appear across the docs site, all fixed here:

- `docs/getting-started.md`, `docs/kospex.md`, `docs/branch-aware-sync.md`, `docs/web-endpoint-testing.md` — `kospex sync` → `kospex sync-directory`, `init --default` → `init --create`
- `README.short.md` is the PyPI readme; its only link, `kospex.io/getting-started`, returned **404** → `docs.kospex.io/getting-started`

I verified `kospex sync-directory .` syncs a single repo root before recommending it as the replacement (`find_repos` walks from the directory itself), and ran every command in the new README before documenting it.

## Reviewing

The rendered `README.md` is the real deliverable — worth reading on the Files tab rather than as a diff.

## Follow-up, not in this PR

`get_repos()` applies the `_git_server` filter twice — `set_params_by_id()` resolves it from the kwargs it is handed, then the explicit block two lines later repeats it. Idempotent under `AND` so row counts are correct, but redundant. Removing it is a small behaviour decision (`repo_id` + `server` would scope by `repo_id` alone), so it is tracked separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
