### PR TITLE
fix(deps): run the demote and upsert in one transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,20 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
   `developer_stats` update.
 
 ### Fixed
+- **A failed dependency save left a manifest with zero current dependencies.**
+  `save_dependencies()` ran its demote (`UPDATE ... SET latest = 0` for every
+  prior row of the `(_repo_id, file_path)` being rewritten) and its
+  `upsert_all()` as two statements with no transaction. If the upsert failed,
+  the demote was already committed and the replacement rows were never written,
+  so every "current dependencies" view for that file read empty — silently,
+  because the demote itself succeeded. The rows survived at `latest=0` (the
+  demote is an UPDATE, never a DELETE), so the data was recoverable, but it was
+  no longer reported. The two statements now run inside a single
+  `Database.atomic()` transaction, so a failed upsert rolls the demote back and
+  the previous dependency set stays current. `sqlite-utils>=4.1.1` is now
+  declared in `pyproject.toml`, matching the existing `requirements.txt` pin:
+  `atomic()` issues an explicit `BEGIN`, and sqlite3's `with conn:` does **not**
+  roll the demote back here. See `changes/202608-save-dependencies-atomic.md`.
 - **`kospex list-repos -db -repo_id` returned no rows.** `list-repos` defines
   `-repo_id` as an `is_flag` option meaning "add the Repo ID column to the
   output", but the whole kwargs dict is forwarded to

--- a/changes/202608-save-dependencies-atomic.md
+++ b/changes/202608-save-dependencies-atomic.md
@@ -1,0 +1,106 @@
+# save_dependencies(): demote and upsert in one transaction
+
+## Overview
+
+`KospexDependencies.save_dependencies()` ran two DB statements with no
+transaction between them. If the second failed, the first stayed committed and
+the manifest was left reporting zero current dependencies — silently, because
+the statement that caused the damage succeeded.
+
+This is a durability bug in the write path. It stands independently of whether
+DB migrations have been applied.
+
+## Problem
+
+`save_dependencies()` does two things:
+
+1. Demote every prior `latest=1` row for each `(_repo_id, file_path)` being
+   rewritten (`UPDATE ... SET latest = 0`).
+2. Upsert the incoming records with `latest=1`.
+
+Run as separate statements, a failure in step 2 leaves step 1 committed. The
+file then has no rows at `latest=1` at all: every current-dependencies view for
+that manifest reads empty.
+
+Nothing is deleted — the rows survive at `latest=0`, and the demote is an
+UPDATE, never a DELETE — so the data is recoverable by fixing the cause and
+re-syncing. But until then it is not reported.
+
+Reproduced against a database missing the `resolution` column, with a fresh
+connection and a reopened file to prove the loss is committed rather than
+uncommitted state visible on the writing handle:
+
+```
+before (same conn):  3
+save_dependencies raised: OperationalError
+after  (same conn):  0
+conn.in_transaction: False
+after  (other conn): 0   <-- committed state
+after  (reopened):   0   <-- survives process exit
+```
+
+### Why the exposure widened
+
+`a298f97` changed the demote from `(_repo_id, file_path, package_name)` to
+`(_repo_id, file_path)`. That is correct — keying on the package name left
+renamed and removed packages stuck at `latest=1` forever — but it means a
+failure now clears the whole manifest rather than only the packages in the
+incoming batch.
+
+### The trigger is general
+
+A pre-0005 database hitting `table dependency_data has no column named
+resolution` is the case seen in the wild, and closing that migration gap removes
+that particular trigger. It does not fix this: any transient error between the
+two statements — a lock timeout, a disk error, a malformed record — produces the
+same silent blanking.
+
+## Fix
+
+Both statements now run inside one `Database.atomic()` block, so a failed upsert
+rolls the demote back and the previous dependency set stays current. The
+exception still propagates: the caller must know the write failed.
+
+`atomic()` is required rather than sqlite3's `with conn:`. The latter relies on
+the implicit transaction and does **not** protect the demote here, because
+something inside `upsert_all()` ends it. `atomic()` issues an explicit `BEGIN`,
+and nests via savepoints if a caller already holds a transaction. Measured
+directly:
+
+```
+with conn:     -> LOST ROWS (n=0)
+db.atomic()    -> ROLLED BACK (safe)
+```
+
+`cleaned` is built before the block — it is pure computation and does not need
+to hold the transaction open.
+
+## Files changed
+
+- `src/kospex_dependencies.py` — `save_dependencies()` wraps the demote and the
+  upsert in `self.kospex_db.atomic()`
+- `pyproject.toml` — `sqlite-utils` floored at `>=4.1.1` for `Database.atomic()`,
+  matching the pin already in `requirements.txt`
+- `tests/test_dependencies_save.py` — regression test
+- `CHANGELOG.md`
+
+## Testing
+
+`test_upsert_failure_leaves_prior_rows_current` seeds three current rows, drives
+a save whose upsert must fail, and asserts all three are still `latest=1`.
+
+The failure is triggered with a deliberately generic unknown column rather than
+`resolution`, so the test keeps testing the durability property rather than the
+migration gap once that gap closes.
+
+## Not addressed
+
+The other two `upsert_all` call sites in this file (the assess path and the
+`store` path) have **no demote**, so they cannot blank a manifest and are not
+affected by this bug.
+
+They do set `latest = 1` without demoting anything, which means they can leave
+renamed or removed packages stuck at `latest=1` — the same problem `a298f97`
+fixed for `save_dependencies()`, still present in that writer. That is a
+correctness issue, not a durability one, and needs a decision about whether
+those paths should demote at all. Tracked separately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,10 @@ dependencies = [
     "packaging",
     "panopticas>=0.0.18",
     "python-dotenv",
-    "sqlite-utils",
+    # >=4.1.1 for Database.atomic(): save_dependencies() needs an explicit
+    # BEGIN to roll a failed upsert back. sqlite3's `with conn:` does not
+    # work here. Matches the pin already in requirements.txt.
+    "sqlite-utils>=4.1.1",
     "requests==2.33.0",
     "rich>=14.0.0",
     "python-multipart>=0.0.20",

--- a/src/kospex_dependencies.py
+++ b/src/kospex_dependencies.py
@@ -522,12 +522,6 @@ class KospexDependencies:
             (r.get("_repo_id"), r.get("file_path"))
             for r in records
         }
-        for repo_id, file_path in demote_keys:
-            self.kospex_db.execute(
-                f"UPDATE {KospexSchema.TBL_DEPENDENCY_DATA} SET latest = 0 "
-                "WHERE _repo_id = ? AND file_path = ?",
-                [repo_id, file_path],
-            )
 
         cleaned = []
         for r in records:
@@ -546,13 +540,31 @@ class KospexDependencies:
                     rec["_git_repo"] = parts["repo"]
             cleaned.append(rec)
 
-        self.kospex_db.table(KospexSchema.TBL_DEPENDENCY_DATA).upsert_all(
-            cleaned,
-            pk=[
-                "_repo_id", "hash", "file_path",
-                "package_type", "package_name", "package_version",
-            ],
-        )
+        # The demote and the upsert are one unit of work. Run as two statements
+        # with no transaction, a failed upsert leaves the demote committed and
+        # the replacements never written — the manifest silently reports zero
+        # current dependencies, because the demote itself succeeded.
+        #
+        # atomic() is required rather than sqlite3's `with conn:`: the latter
+        # relies on the implicit transaction and does NOT roll the demote back
+        # here, because something inside upsert_all ends it. atomic() issues an
+        # explicit BEGIN, and nests via savepoints if a caller already has a
+        # transaction open.
+        with self.kospex_db.atomic():
+            for repo_id, file_path in demote_keys:
+                self.kospex_db.execute(
+                    f"UPDATE {KospexSchema.TBL_DEPENDENCY_DATA} SET latest = 0 "
+                    "WHERE _repo_id = ? AND file_path = ?",
+                    [repo_id, file_path],
+                )
+
+            self.kospex_db.table(KospexSchema.TBL_DEPENDENCY_DATA).upsert_all(
+                cleaned,
+                pk=[
+                    "_repo_id", "hash", "file_path",
+                    "package_type", "package_name", "package_version",
+                ],
+            )
 
         return len(cleaned)
 

--- a/tests/test_dependencies_save.py
+++ b/tests/test_dependencies_save.py
@@ -262,3 +262,40 @@ def test_demote_is_scoped_to_the_repo_being_written():
              if r["_repo_id"] == "github.com~other~repo"]
     assert len(other) == 1
     assert other[0]["latest"] == 1, "another repo's rows must not be demoted"
+
+
+def test_upsert_failure_leaves_prior_rows_current():
+    """A failed upsert must not blank the manifest's current dependencies.
+
+    The demote and the upsert are one unit of work. Run as two statements with
+    no transaction, a failure between them leaves the demote committed and the
+    replacements never written, so the file ends up with zero rows at latest=1
+    -- silently, because the demote itself succeeded.
+    """
+    import sqlite3
+
+    db = _make_db()
+    kdeps = KospexDependencies(kospex_db=db)
+    for name in ("requests", "click", "urllib3"):
+        _existing_row(db, package_name=name, package_version="1.0.0")
+
+    # `not_a_column` is not in the schema and is not stripped as a template
+    # field, so the upsert raises after the demote has already run. The trigger
+    # is deliberately generic -- any DB error between the two statements does
+    # this; a pre-0005 DB hitting `resolution` is just the case seen in the wild.
+    with pytest.raises(sqlite3.OperationalError):
+        kdeps.save_dependencies([{
+            "_repo_id": "github.com~kospex~kospex",
+            "hash": "newhash",
+            "file_path": "requirements.txt",
+            "package_type": "pypi",
+            "package_name": "requests",
+            "package_version": "2.31.0",
+            "not_a_column": "boom",
+        }], source="krunner osi")
+
+    current = [r for r in db[KospexSchema.TBL_DEPENDENCY_DATA].rows if r["latest"] == 1]
+    assert {r["package_name"] for r in current} == {"requests", "click", "urllib3"}, (
+        "the demote must roll back with the failed upsert, leaving the previous "
+        "dependency set current"
+    )


### PR DESCRIPTION
## Problem

`KospexDependencies.save_dependencies()` runs two DB statements with no transaction between them:

1. Demote every prior `latest=1` row for each `(_repo_id, file_path)` being rewritten (`UPDATE ... SET latest = 0`)
2. Upsert the incoming records with `latest=1`

If step 2 fails, step 1 is already committed. The manifest is then left with **no rows at `latest=1` at all** — every current-dependencies view for that file reads empty. Silently, because the statement that caused the damage succeeded.

Nothing is deleted: the rows survive at `latest=0` and the demote is an UPDATE, never a DELETE. So it is recoverable by fixing the cause and re-syncing — but until then it is not reported.

Reproduced against a DB missing the `resolution` column, reading back through a **separate connection** and a **reopened file** to prove the loss is committed rather than uncommitted state visible on the writing handle:

```
before (same conn):  3
save_dependencies raised: OperationalError
after  (same conn):  0
conn.in_transaction: False
after  (other conn): 0   <-- committed state
after  (reopened):   0   <-- survives process exit
```

### Why the exposure widened

`a298f97` changed the demote from `(_repo_id, file_path, package_name)` to `(_repo_id, file_path)`. That change is correct — keying on the package name left renamed and removed packages stuck at `latest=1` forever — but it means a failure now clears the **whole manifest** rather than only the packages in the incoming batch.

### The trigger is general

A pre-0005 database hitting `table dependency_data has no column named resolution` is the case seen in the wild, and closing that migration gap removes that particular trigger. It does not fix this. Any transient error between the two statements — a lock timeout, a disk error, a malformed record — produces the same silent blanking. Hence this is scoped as its own fix.

## Fix

Both statements now run inside a single `Database.atomic()` block, so a failed upsert rolls the demote back and the previous dependency set stays current. The exception still propagates — the caller must know the write failed.

### `atomic()` is required, not `with conn:`

The obvious dependency-free wrapper does **not** work here. `with conn:` relies on the implicit transaction, and something inside `upsert_all()` ends it. Measured directly rather than assumed:

```
with conn:     -> LOST ROWS (n=0)
db.atomic()    -> ROLLED BACK (safe)
```

`atomic()` issues an explicit `BEGIN`, and nests via savepoints if a caller already holds a transaction. `upsert_all()` does not open a transaction of its own, so the wrapper composes cleanly.

This is why `pyproject.toml` now floors `sqlite-utils` at `>=4.1.1` — it was previously unpinned there, so `atomic()` was not guaranteed to exist. The floor matches the pin already in `requirements.txt`, so no real install changes.

## Testing

`test_upsert_failure_leaves_prior_rows_current` seeds three current rows, drives a save whose upsert must fail, and asserts all three are still `latest=1`.

Written test-first and confirmed failing for the right reason before the fix:

```
E   AssertionError: the demote must roll back with the failed upsert...
E   assert set() == {'requests', 'urllib3', 'click'}
```

The failure is triggered with a deliberately generic unknown column rather than `resolution`, so the test keeps testing the durability property rather than the migration gap once that gap closes.

Full suite: **485 passed, 75 skipped, 0 failures.**

## Not addressed

The other two `upsert_all` call sites in this file (the assess path and the `store` path) have **no demote**, so they cannot blank a manifest and are unaffected by this bug.

They do set `latest = 1` without demoting anything, which means they can leave renamed or removed packages stuck at `latest=1` — the same problem `a298f97` fixed for `save_dependencies()`, still present in that writer. That is a correctness issue rather than a durability one, and it needs a decision about whether those paths should demote at all. Worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
