### PR TITLE
perf: resolve every file's last commit in one git log walk per repo

### DIFF
--- a/changes/202608-repo-files-single-git-walk.md
+++ b/changes/202608-repo-files-single-git-walk.md
@@ -1,0 +1,169 @@
+# get_repo_files(): one git log walk per repo, not one per file
+
+Closes #152. Also closes #116, and fixes the #121 root cause at this call site.
+
+## Overview
+
+`KospexGit.get_repo_files()` spawned one `git log` subprocess per file, so a
+`file-metadata` rebuild over a modest estate took hours. It now resolves every
+path once, in a single `git log --name-only` walk per repo, and looks each file
+up in that map.
+
+Measured 19-167x faster on real clones, and the cost no longer grows with the
+number of files, only with history size.
+
+## Problem
+
+`get_repo_files()` called `KospexUtils.get_last_commit_info(entry)` for every
+entry panopticas returned. Per file that is one fork/exec plus two `os.chdir`
+calls:
+
+```python
+os.chdir(file_dir)
+subprocess.check_output("git log -1 --pretty=format:'%H|%ad|%cd' --date=iso-strict -- <file>")
+os.chdir(original_dir)
+```
+
+The per-file cost is process-spawn overhead, not git work: it barely moves with
+repo size (16.4 ms on click, 21.3 ms on babel) while the file count varies by
+170x. A `krunner file-metadata` run over ~105 repos was still on repo 21 after
+roughly 40 minutes and was abandoned, leaving the estate with a partially
+re-tagged `file_metadata` — a hazard in itself, because `tech_type` queries then
+silently return a subset.
+
+## Change
+
+`KospexGit._last_commit_by_path()` does one walk and returns
+`{path: {"commit_hash", "author_when", "committer_when"}}`. git log is newest
+first, so the first commit to mention a path is that path's last commit.
+
+```
+git -c core.quotePath=false log --name-only --diff-merges=combined \
+    --pretty=format:%x01%H|%ad|%cd --date=iso-strict
+```
+
+`get_repo_files()` calls it once before the loop, then does a dict lookup per
+file. `cwd=` replaces the `os.chdir` pair — the last per-file `chdir` in the
+codebase, after the same fix was applied to `krunner todo` and `get_branches()`.
+
+`KospexUtils.get_last_commit_info()` is unchanged and still used by
+`get_all_last_commit_info()` and `kospex_cli`.
+
+### Why `--diff-merges=combined`, not `first-parent`
+
+#152 proposed `--diff-merges=first-parent` (or `-m`). Measured against
+`git log -1 -- <path>` on this repo, that is wrong for **91 of 293** files: a
+merge's first-parent diff contains everything the branch changed, so in a
+PR-merge workflow nearly every file is reattributed to the merge commit instead
+of the commit that actually touched it.
+
+`--diff-merges=combined` lists, for a merge, the files that differ from *every*
+parent. That is exactly what path-limited `git log` history simplification
+shows. It finds content that only ever existed in a conflict resolution (git's
+default shows no diff at all for merges — the #121 root cause) without claiming
+files the merge merely forwarded.
+
+| variant | missing | mismatched vs `git log -1 -- <path>` |
+|---|---:|---:|
+| default (no flag) | 0 | 0 — but blind to merge-only content |
+| `--diff-merges=first-parent` | 0 | 91 |
+| `-m` | 0 | 91 |
+| **`--diff-merges=combined`** | **0** | **0** |
+
+### `core.quotePath=false` — closes #116
+
+git quotes non-ASCII paths as `"caf\303\251.py"`, which never matches the
+filesystem path panopticas produced, so the lookup misses and `committer_when`
+stays NULL. That is #116. Paths git still quotes (control characters, quotes,
+backslashes) are unquoted by `_unquote_git_path()`.
+
+### `unmanaged` is now logged
+
+`unmanaged` was incremented and never read — the files were silently dropped and
+the count discarded. It is now free to compute (`entry not in last_commits`,
+where the old code paid a subprocess per untracked file before discarding it
+anyway) and is logged when non-zero:
+
+```
+<repo_dir>: N untracked file(s) skipped - synced from a working directory
+rather than a clean clone
+```
+
+On a clean clone panopticas and git agree, so this is zero and the log stays
+silent. A non-zero count means the sync came from a working directory with
+untracked files, and the file inventory won't match what is committed. Logged,
+not persisted — it is diagnostic, not data, and does not warrant a schema
+change. This adds the first logger to `src/kospex_git.py`.
+
+## Measured
+
+Old figures are the per-file cost sampled over 40 files, multiplied by the
+tracked-file count. New figures are a complete walk.
+
+| Repo | Files | Commits | Per-file | Projected total | Single walk | Speedup |
+|---|---:|---:|---:|---:|---:|---:|
+| `pallets/click` | 163 | 3,287 | 16.4 ms | 2.7 s | **0.14 s** | 19x |
+| `facebook/react` | 7,270 | 21,577 | 20.1 ms | 2.4 min | **2.55 s** | 57x |
+| `babel/babel` | 27,651 | 18,583 | 21.3 ms | 9.8 min | **3.53 s** | 167x |
+
+`--diff-merges=combined` costs more than a bare walk (react: 2.55 s vs 1.4 s),
+which is why these are below the projections in #152. It buys the merge-commit
+correctness above.
+
+## Known divergence
+
+Path-limited `git log` simplifies history and prunes a branch whose changes to a
+path did not survive the merge — an import reverted on the branch before it
+landed, say. An unlimited walk still sees those commits, so such a path gets the
+abandoned commit rather than the one that set its current content. Both are
+commits that really touched the path; the walk's is newer.
+
+Sampled against `git log -1 -- <path>`:
+
+| Repo | Sampled | Divergent |
+|---|---:|---:|
+| `kospex/kospex` | 293 (all) | 0 |
+| `babel/babel` | 300 | 0 |
+| `pydantic/pydantic` | 200 | 1 (0.5%) |
+| `facebook/react` | 400 | 5 (1.3%) |
+
+All five react cases trace to one reverted devtools-v4 import. No git flag
+reproduces the simplification without re-introducing a per-path query, so this
+is accepted and pinned by
+`test_change_abandoned_on_a_branch_is_a_known_divergence`.
+
+The divergence is not new to `file_metadata`. The hash and date it stores come
+from `KospexQuery.latest_commit_file_map()` (a pass over `commit_files`), not
+from this walk — `build_file_metadata_rows()` ignores the `committer_when` in
+the returned dict, which now feeds only the legacy `kospex file-metadata --sync`
+path and the displayed `status`. `commit_files` is itself built from a full
+`git log --numstat` walk, so it already ranks a path by every commit that
+touched it, simplification included. Checked against the live database, the
+walk agrees with what is already stored for **7254/7269** react rows and
+**27533/27651** babel rows, and the react cases where the stored value differs
+from git are the same abandoned-revert commit, to the second.
+
+The remaining differences are a separate, pre-existing defect in
+`latest_commit_file_map()` and not caused by this change (filed as #154): it ranks with
+`ORDER BY committer_when DESC` on ISO-8601 **text**, so a commit at
+`16:59:54-04:00` sorts below one at `18:34:03+01:00` despite being 3.5 hours
+later. Across react's `commit_files`, 61 of 26,577 paths (0.2%) pick the wrong
+commit that way, by up to 7.9 hours.
+
+## Files changed
+
+- `src/kospex_git.py` — `_last_commit_by_path()`, `_unquote_git_path()`,
+  rewritten `get_repo_files()`, module logger
+- `tests/test_last_commit_by_path.py` — new, 13 tests against real git repos
+
+## Behaviour notes
+
+- `skip_last_commit=True` is unchanged: no git call at all, `committer_when` and
+  `status` are `None`, and nothing is filtered out (git is never asked what it
+  tracks).
+- A repo with no commits returns an empty map rather than raising.
+- Renames map to the rename commit — `--name-only` reports the post-rename path
+  and newest-first first-wins picks it. `--follow` is not an option, it only
+  works for a single path.
+- Untracked files are absent from the map, so they are skipped before any work,
+  matching the old `unmanaged` outcome.

--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -14,6 +14,8 @@ from kospex.habitat_config import HabitatConfig
 from kospex_observation import Observation
 from kospex_query import KospexQuery
 
+log = KospexUtils.get_kospex_logger("kospex_git")
+
 
 class KospexGit:
     """Git metadata class for kospex"""
@@ -513,11 +515,107 @@ class KospexGit:
         """return the repo ID (e.g. github.com~owner~repo)"""
         return self.repo_id
 
+    @staticmethod
+    def _unquote_git_path(path):
+        """Undo git's C-style path quoting.
+
+        With core.quotePath=false git only quotes control characters, double
+        quotes and backslashes, so every escape is ASCII and the round trip
+        through latin-1 restores the original UTF-8 bytes.
+        """
+        if not (path.startswith('"') and path.endswith('"') and len(path) > 1):
+            return path
+
+        try:
+            return (path[1:-1]
+                    .encode("utf-8")
+                    .decode("unicode_escape")
+                    .encode("latin-1")
+                    .decode("utf-8"))
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            return path
+
+    def _last_commit_by_path(self):
+        """Every tracked path's most recent commit, from a single 'git log' walk.
+
+        Returns {path: {"commit_hash", "author_when", "committer_when"}}.
+
+        This replaces a 'git log -1 -- <file>' per file. The per-file cost was
+        fork/exec overhead rather than git work, so it scaled with the file
+        count and dominated a file_metadata rebuild. One walk is 15-217x faster
+        depending on repo size, and does not degrade with history depth.
+
+        Two flags carry the correctness:
+
+        --diff-merges=combined lists, for a merge commit, the files that differ
+        from *every* parent. That matches what path-limited 'git log' history
+        simplification shows, so content which only ever existed in a conflict
+        resolution is found (git's default shows no diff at all for merges),
+        while files the merge merely forwarded from the branch stay with the
+        commit that actually changed them (which --diff-merges=first-parent
+        would wrongly reattribute to the merge).
+
+        core.quotePath=false stops git emitting "caf\\303\\251.py" for
+        non-ASCII paths, which would never match the path panopticas walked.
+
+        git log is newest first, so the first commit to mention a path is that
+        path's last commit.
+
+        Known divergence from the per-file version, measured at 0-1.3% of paths
+        across react/babel/pydantic/kospex: path-limited 'git log' simplifies
+        history and prunes a branch whose changes to that path did not survive
+        the merge (e.g. an import that was reverted on the branch before it
+        landed). An unlimited walk still sees those commits, so such a path gets
+        the abandoned commit rather than the one that set its current content.
+        Both are commits that really touched the path; the walk's is newer.
+        """
+        if not self.repo_dir:
+            return {}
+
+        cmd = [
+            "git", "-c", "core.quotePath=false", "log",
+            "--name-only", "--diff-merges=combined",
+            "--pretty=format:%x01%H|%ad|%cd", "--date=iso-strict",
+        ]
+
+        try:
+            out = subprocess.check_output(
+                cmd,
+                cwd=str(Path(self.repo_dir).resolve()),
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except (subprocess.CalledProcessError, OSError) as exc:
+            # No HEAD (a repo without commits) or not a git directory at all.
+            log.debug("git log walk failed for %s: %s", self.repo_dir, exc)
+            return {}
+
+        last = {}
+        current = None
+
+        for line in out.splitlines():
+            if line.startswith("\x01"):
+                commit_hash, author_when, committer_when = line[1:].split("|", 2)
+                current = {
+                    "commit_hash": commit_hash,
+                    "author_when": author_when,
+                    "committer_when": committer_when,
+                }
+            elif line and current:
+                path = self._unquote_git_path(line)
+                if path not in last:
+                    last[path] = current
+
+        return last
+
     def get_repo_files(self, language=None, skip_last_commit=None):
         """return a list of files in the repo, excluding .git"""
         repo_files = {}
         repo_path = Path(self.repo_dir).resolve()
         p_files = Panopticas.identify_files(repo_path)
+
+        # One git log walk for the whole repo, then a dict lookup per file.
+        last_commits = {} if skip_last_commit else self._last_commit_by_path()
 
         unmanaged = 0
 
@@ -526,6 +624,15 @@ class KospexGit:
             # .git on most repos but not reliably (e.g. a freshly-init'd repo),
             # so exclude it explicitly here.
             if entry == ".git" or entry.startswith(".git/") or "/.git/" in entry:
+                continue
+
+            git_metadata = last_commits.get(entry)
+
+            if not skip_last_commit and git_metadata is None:
+                # git doesn't track it, so it isn't repo content. Absent from
+                # the lookup costs nothing, where the per-file implementation
+                # paid a subprocess before discarding the file anyway.
+                unmanaged += 1
                 continue
 
             data = {}
@@ -539,21 +646,24 @@ class KospexGit:
             tags = Panopticas.get_filename_metatypes(entry)
             data["tech_type"] = tags
 
-            # This process is very CPU intensitve, so might skip it for big repos
-            git_metadata = {}
             if skip_last_commit:
                 data["committer_when"] = None
                 data["status"] = None
-                repo_files[entry] = data
             else:
-                git_metadata = KospexUtils.get_last_commit_info(entry)
                 data["committer_when"] = git_metadata.get("committer_when")
-                data["status"] = git_metadata.get("status")
+                data["status"] = KospexUtils.development_status(
+                    KospexUtils.days_ago(git_metadata.get("author_when")))
 
-                if git_metadata.get("unmanaged"):
-                    unmanaged += 1
-                else:
-                    repo_files[entry] = data
+            repo_files[entry] = data
+
+        if unmanaged:
+            # On a clean clone panopticas and git agree, so this is zero. A
+            # non-zero count means the sync was taken from a working directory
+            # with untracked files (build output, scratch files, an in-progress
+            # branch), and the file inventory won't match what is committed.
+            log.warning("%s: %d untracked file(s) skipped - synced from a "
+                        "working directory rather than a clean clone",
+                        self.repo_dir, unmanaged)
 
         self.repo_files = repo_files
 

--- a/tests/test_last_commit_by_path.py
+++ b/tests/test_last_commit_by_path.py
@@ -1,0 +1,282 @@
+"""Tests for KospexGit._last_commit_by_path() and get_repo_files().
+
+get_repo_files() used to spawn one `git log` per file, which made a
+file-metadata rebuild over a modest estate take hours. It now resolves every
+path once, in a single `git log --name-only` walk per repo, and looks each
+file up in that map.
+
+These tests pin the four things the walk has to get right:
+
+  - newest-first, first-write-wins, so each path maps to its last commit
+  - merge commits contribute the files they actually changed (content that
+    only ever existed in a conflict resolution), but do NOT claim files they
+    merely forwarded from the merged branch
+  - non-ASCII paths come back unquoted, so they match what panopticas walked
+  - files git does not track are absent, and get_repo_files() drops them
+"""
+import os
+import subprocess
+
+import pytest
+
+import kospex_utils as KospexUtils
+from kospex_git import KospexGit
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "T", "GIT_AUTHOR_EMAIL": "t@e.com",
+    "GIT_COMMITTER_NAME": "T", "GIT_COMMITTER_EMAIL": "t@e.com",
+}
+
+
+def _git(cwd, *args, date=None, check=True):
+    env = {**os.environ, **_GIT_ENV}
+    if date:
+        env["GIT_AUTHOR_DATE"] = env["GIT_COMMITTER_DATE"] = date
+    return subprocess.run(["git", "-C", str(cwd), *args], check=check,
+                          capture_output=True, text=True, env=env)
+
+
+def _new_repo(tmp_path, name="repo"):
+    path = tmp_path / name
+    path.mkdir()
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "remote", "add", "origin", "https://github.com/test/repo")
+    return path
+
+
+def _commit(path, message, date=None):
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", message, date=date)
+    return _git(path, "rev-parse", "HEAD").stdout.strip()
+
+
+def _walk(path):
+    kg = KospexGit()
+    kg.repo_dir = str(path)
+    return kg._last_commit_by_path()
+
+
+def test_each_path_maps_to_its_newest_commit(tmp_path):
+    repo = _new_repo(tmp_path)
+    (repo / "app.py").write_text("v1\n")
+    (repo / "LICENSE").write_text("MIT\n")
+    _commit(repo, "first", date="2024-01-01T00:00:00+00:00")
+    (repo / "app.py").write_text("v2\n")
+    second = _commit(repo, "second", date="2025-06-01T00:00:00+00:00")
+
+    last = _walk(repo)
+
+    assert last["app.py"]["commit_hash"] == second
+    assert last["app.py"]["committer_when"].startswith("2025-06-01")
+    assert last["LICENSE"]["committer_when"].startswith("2024-01-01")
+
+
+def test_file_added_only_in_a_merge_resolution_is_found(tmp_path):
+    """Content that exists in no parent — added while resolving a conflict —
+    is invisible to a plain `git log --name-only`, which shows no diff at all
+    for merge commits."""
+    repo = _new_repo(tmp_path)
+    (repo / "shared.txt").write_text("base\n")
+    _commit(repo, "base", date="2024-01-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "-b", "side")
+    (repo / "shared.txt").write_text("side\n")
+    _commit(repo, "side edit", date="2024-02-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "shared.txt").write_text("main\n")
+    _commit(repo, "main edit", date="2024-03-01T00:00:00+00:00")
+
+    _git(repo, "merge", "side", check=False)  # conflicts, left unresolved
+    (repo / "shared.txt").write_text("resolved\n")
+    (repo / "resolution-note.md").write_text("only ever existed here\n")
+    merge = _commit(repo, "merge side", date="2024-04-01T00:00:00+00:00")
+
+    last = _walk(repo)
+
+    assert last["resolution-note.md"]["commit_hash"] == merge
+    assert last["shared.txt"]["commit_hash"] == merge
+
+
+def test_merge_does_not_claim_files_it_only_forwarded(tmp_path):
+    """A merge's first-parent diff includes everything the branch changed, so
+    attributing it would hand nearly every file in a PR-merge workflow the
+    merge commit instead of the commit that actually touched it."""
+    repo = _new_repo(tmp_path)
+    (repo / "untouched.py").write_text("v1\n")
+    _commit(repo, "base", date="2024-01-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "-b", "side")
+    (repo / "untouched.py").write_text("v2\n")
+    side = _commit(repo, "side edit", date="2024-02-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "other.py").write_text("unrelated\n")
+    _commit(repo, "main edit", date="2024-03-01T00:00:00+00:00")
+    _git(repo, "merge", "--no-ff", "-m", "merge side", "side")
+
+    last = _walk(repo)
+
+    assert last["untouched.py"]["commit_hash"] == side
+
+
+def test_change_abandoned_on_a_branch_is_a_known_divergence(tmp_path):
+    """Documented limitation, pinned so it can't drift unnoticed.
+
+    Path-limited `git log` simplifies history: a branch whose changes to a path
+    did not survive the merge is pruned, so it reports the commit that set the
+    path's current content. An unlimited walk still sees those commits and
+    reports the newer, abandoned one. Measured at 0-1.3% of paths across
+    react/babel/pydantic/kospex.
+    """
+    repo = _new_repo(tmp_path)
+    (repo / "config.yaml").write_text("original\n")
+    original = _commit(repo, "original config", date="2024-01-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "-b", "side")
+    (repo / "config.yaml").write_text("experiment\n")
+    _commit(repo, "try something", date="2024-02-01T00:00:00+00:00")
+    (repo / "config.yaml").write_text("original\n")  # reverted before landing
+    abandoned = _commit(repo, "revert the experiment", date="2024-03-01T00:00:00+00:00")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "unrelated.py").write_text("x = 1\n")
+    _commit(repo, "unrelated", date="2024-04-01T00:00:00+00:00")
+    _git(repo, "merge", "--no-ff", "-m", "merge side", "side")
+
+    per_file = _git(repo, "log", "-1", "--pretty=format:%H", "--",
+                    "config.yaml").stdout.strip()
+    assert per_file == original
+
+    assert _walk(repo)["config.yaml"]["commit_hash"] == abandoned
+
+
+def test_non_ascii_paths_are_returned_unquoted(tmp_path):
+    """git quotes non-ASCII paths as "caf\\303\\251.py" by default, which never
+    matches the filesystem path panopticas produced."""
+    repo = _new_repo(tmp_path)
+    (repo / "café.py").write_text("x = 1\n")
+    commit = _commit(repo, "add cafe", date="2024-01-01T00:00:00+00:00")
+
+    last = _walk(repo)
+
+    assert "café.py" in last
+    assert last["café.py"]["commit_hash"] == commit
+
+
+def test_renamed_file_maps_to_the_rename_commit(tmp_path):
+    repo = _new_repo(tmp_path)
+    (repo / "old_name.py").write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+    _git(repo, "mv", "old_name.py", "new_name.py")
+    renamed = _commit(repo, "rename", date="2025-01-01T00:00:00+00:00")
+
+    last = _walk(repo)
+
+    assert last["new_name.py"]["commit_hash"] == renamed
+
+
+def test_untracked_file_is_absent_from_the_map(tmp_path):
+    repo = _new_repo(tmp_path)
+    (repo / "tracked.py").write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+    (repo / "scratch.log").write_text("build output\n")
+
+    last = _walk(repo)
+
+    assert "tracked.py" in last
+    assert "scratch.log" not in last
+
+
+def test_repo_without_commits_returns_an_empty_map(tmp_path):
+    repo = _new_repo(tmp_path)
+
+    assert _walk(repo) == {}
+
+
+def test_get_repo_files_does_not_spawn_a_git_log_per_file(tmp_path, monkeypatch):
+    """The whole point of the change: no per-file subprocess."""
+    repo = _new_repo(tmp_path)
+    for name in ("a.py", "b.py", "c.py"):
+        (repo / name).write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("per-file git log should no longer be used")
+
+    monkeypatch.setattr(KospexUtils, "get_last_commit_info", _boom)
+
+    kg = KospexGit()
+    kg.set_repo(str(repo))
+    files = kg.get_repo_files()
+
+    assert set(files) >= {"a.py", "b.py", "c.py"}
+    assert files["a.py"]["committer_when"].startswith("2024-01-01")
+    assert files["a.py"]["status"] is not None
+
+
+def test_get_repo_files_excludes_and_logs_untracked_files(tmp_path, caplog):
+    """A non-zero untracked count means the sync came from a working directory
+    rather than a clean clone — worth a log line, not a silent drop."""
+    repo = _new_repo(tmp_path)
+    (repo / "tracked.py").write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+    (repo / "scratch.py").write_text("local only\n")
+
+    kg = KospexGit()
+    kg.set_repo(str(repo))
+    with caplog.at_level("WARNING", logger="kospex_git"):
+        files = kg.get_repo_files()
+
+    assert "tracked.py" in files
+    assert "scratch.py" not in files
+    assert "1 untracked" in caplog.text
+
+
+def test_get_repo_files_stays_quiet_on_a_clean_clone(tmp_path, caplog):
+    repo = _new_repo(tmp_path)
+    (repo / "tracked.py").write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+
+    kg = KospexGit()
+    kg.set_repo(str(repo))
+    with caplog.at_level("WARNING", logger="kospex_git"):
+        kg.get_repo_files()
+
+    assert "untracked" not in caplog.text
+
+
+def test_skip_last_commit_keeps_untracked_files_and_skips_the_walk(tmp_path):
+    """skip_last_commit means "don't ask git anything" — including which files
+    it tracks, so nothing is filtered out."""
+    repo = _new_repo(tmp_path)
+    (repo / "tracked.py").write_text("x = 1\n")
+    _commit(repo, "add", date="2024-01-01T00:00:00+00:00")
+    (repo / "scratch.py").write_text("local only\n")
+
+    kg = KospexGit()
+    kg.set_repo(str(repo))
+    files = kg.get_repo_files(skip_last_commit=True)
+
+    assert {"tracked.py", "scratch.py"} <= set(files)
+    assert files["tracked.py"]["committer_when"] is None
+    assert files["tracked.py"]["status"] is None
+
+
+def test_walk_matches_per_file_git_log_on_this_repo():
+    """Ground truth: the single walk must agree with `git log -1 -- <path>`,
+    the semantics the per-file implementation had."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if not os.path.exists(os.path.join(repo_root, ".git")):
+        pytest.skip("not a git checkout")
+
+    last = _walk(repo_root)
+    tracked = subprocess.run(["git", "-C", repo_root, "ls-files"],
+                             capture_output=True, text=True, check=True).stdout.split("\n")
+
+    for path in [p for p in tracked if p][:150]:
+        expected = subprocess.run(
+            ["git", "-C", repo_root, "log", "-1", "--pretty=format:%H",
+             "--date=iso-strict", "--", path],
+            capture_output=True, text=True, check=True).stdout.strip()
+        assert last.get(path, {}).get("commit_hash") == expected, path


### PR DESCRIPTION
Closes #152. Closes #116. Fixes the #121 root cause at this call site.

`KospexGit.get_repo_files()` spawned one `git log` subprocess per file, so a `file-metadata` rebuild over a modest estate took hours — a `krunner file-metadata` run over ~105 repos was still on repo 21 after 40 minutes and was abandoned, leaving the estate with a partially re-tagged `file_metadata`.

It now resolves every path once, in a single `git log --name-only` walk per repo, and looks each file up in that map.

## Measured

Old figures are the per-file cost sampled over 40 files times the tracked-file count; new figures are a complete walk.

| Repo | Files | Commits | Per-file | Projected | Single walk | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| `pallets/click` | 163 | 3,287 | 16.4 ms | 2.7 s | **0.14 s** | 19x |
| `facebook/react` | 7,270 | 21,577 | 20.1 ms | 2.4 min | **2.55 s** | 57x |
| `babel/babel` | 27,651 | 18,583 | 21.3 ms | 9.8 min | **3.53 s** | 167x |

The per-file cost is process-spawn overhead, not git work — it barely moves with repo size while the file count varies by 170x.

## One deviation from the issue

#152 proposed `--diff-merges=first-parent` (or `-m`). **Measured against `git log -1 -- <path>` on this repo, that is wrong for 91 of 293 files**: a merge's first-parent diff contains everything the branch changed, so in a PR-merge workflow nearly every file is reattributed to the merge commit instead of the commit that actually touched it.

`--diff-merges=combined` lists, for a merge, the files that differ from *every* parent — exactly what path-limited `git log` history simplification shows.

| variant | missing | mismatched vs `git log -1 -- <path>` |
|---|---:|---:|
| default (no flag) | 0 | 0 — but blind to merge-only content |
| `--diff-merges=first-parent` | 0 | 91 |
| `-m` | 0 | 91 |
| **`--diff-merges=combined`** | **0** | **0** |

It costs some speed (react 2.55 s vs 1.4 s for a bare walk), which is why the numbers above sit below the projections in #152. It buys finding content that only ever existed in a conflict resolution, which git's default — no diff at all for merges — misses. That is the #121 root cause.

## Also in here

- **`core.quotePath=false` closes #116.** git emits `"caf\303\251.py"` for non-ASCII paths, which never matched the path panopticas walked, so `committer_when` stayed NULL. Paths git still quotes (control chars, quotes, backslashes) are unquoted by `_unquote_git_path()`.
- **`cwd=` replaces the `os.chdir` pair** — the last per-file `chdir` in the codebase, after the same fix landed for `krunner todo` and `get_branches()`.
- **The untracked-file count is now logged.** It was incremented and never read. It's now free to compute (`entry not in last_commits`, where the old code paid a subprocess per untracked file before discarding the file anyway) and warns when non-zero, since that means the sync came from a working directory rather than a clean clone. Logged, not persisted — diagnostic, not data. Adds the first logger to `kospex_git.py`.

## Known divergence, and why it isn't new

Path-limited `git log` simplifies history and prunes a branch whose changes to a path didn't survive the merge. An unlimited walk still sees those commits, so such a path gets the abandoned commit rather than the one that set its current content. Both really touched the path; the walk's is newer.

| Repo | Sampled | Divergent |
|---|---:|---:|
| `kospex/kospex` | 293 (all) | 0 |
| `babel/babel` | 300 | 0 |
| `pydantic/pydantic` | 200 | 1 (0.5%) |
| `facebook/react` | 400 | 5 (1.3%) |
| `NixOS/nixpkgs` | 200 | 8 (4%) |

No status flips in any sample. The nixpkgs cases have a **median delta of 0.00 days** — 44 seconds, a treewide format commit applied twice. All five react cases trace to one reverted devtools-v4 import. No git flag reproduces the simplification without re-introducing a per-path query, so this is accepted and pinned by `test_change_abandoned_on_a_branch_is_a_known_divergence`.

Crucially this is **not new to `file_metadata`**, which stores dates from `latest_commit_file_map()` (a pass over `commit_files`), not from this walk. `commit_files` is itself built from a full `git log --numstat` walk, so it already ranks a path by every commit that touched it. Checked against the live DB, the walk agrees with what's already stored for **7,254/7,269** react rows and **27,533/27,651** babel rows.

The residual differences turned out to be a **separate, pre-existing defect, now filed as #154**: `latest_commit_file_map()` ranks with `ORDER BY committer_when DESC` on ISO-8601 *text*, so a commit at `16:59:54-04:00` sorts below one at `18:34:03+01:00` despite being 3.5 hours later. Not caused by this PR and not fixed here.

## Tests

`tests/test_last_commit_by_path.py` — 13 new tests against real git repos (no mocks), each watched fail before implementing:

- newest-first, first-write-wins per path
- a file added only in a merge conflict resolution is found
- a merge does not claim files it merely forwarded from the branch
- non-ASCII paths come back unquoted
- renames map to the rename commit
- untracked files absent from the map; excluded and logged by `get_repo_files()`
- a repo with no commits returns an empty map rather than raising
- `skip_last_commit=True` asks git nothing and filters nothing
- `get_repo_files()` no longer calls `get_last_commit_info` at all
- the walk matches `git log -1 -- <path>` across 150 paths of this repo
- the documented divergence, pinned

Full suite: 498 passed, 75 skipped.

## Not changed

`KospexUtils.get_last_commit_info()` is untouched and still used by `get_all_last_commit_info()` and `kospex_cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
