### PR TITLE
docs: warn that repo_id is not safe to split on ~

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,14 @@ Design / spec: `changes/202605-db-migration-system.md`.
 
 ### Query Patterns
 - Most tables include `repo_id` in format `GIT_SERVER~OWNER~REPO`
+- **`repo_id` is not safe to `split("~")`.** A `/` in the owner segment (GitLab nested groups /
+  subgroups) is encoded as `~~` by `KospexGit.generate_repo_id()`, so
+  `gitlab.com~group~~subgroup~repo` splits into **five** segments, not three. Indexing `parts[1]`
+  for the owner silently drops the subgroup and shifts the repo name off the end. Build ids with
+  `generate_repo_id()` and parse URLs with `parse_git_remote()` rather than by hand.
+  Note `KospexUtils.parse_repo_id()` currently returns `None` for these ids
+  (`if len(parts) != 3`) — see [#94](https://github.com/kospex/kospex/issues/94). Until that
+  lands, mask `~~` to a sentinel before splitting and restore it after.
 - Author identification primarily uses `author_email` from git
 - Time-based queries often filter by commit date ranges
 - Technology landscape aggregates by file extensions and scc metadata, also uses panopticas


### PR DESCRIPTION
Adds a warning to CLAUDE.md's Query Patterns section that `repo_id` is not safe to `split("~")`.

`KospexGit.generate_repo_id()` encodes a `/` in the owner segment — GitLab nested groups and subgroups — as `~~`. That makes the id **five** segments, not three:

```
generate_repo_id('gitlab.com', 'group/subgroup', 'repo')  ->  gitlab.com~group~~subgroup~repo
len(rid.split('~'))                                       ->  5
```

Indexing `parts[1]` for the owner then silently drops the subgroup and shifts the repo name off the end — no exception, just wrong data.

The note also records the current state of the parser, verified against `main`:

```
KospexUtils.parse_repo_id('gitlab.com~group~~subgroup~repo')  ->  None
```

`src/kospex_utils.py:688` guards with `if len(parts) != 3: return None`, directly under a `# TODO - Make this work with Gitlab URLs which have slashes`. That is #94. Until it lands, callers need to mask `~~` to a sentinel before splitting and restore it after — which is what the note says to do.

## Scope

Documentation only. One file, +8 lines, no code change and no behaviour change.

## Expiry

The last two lines are an interim workaround tied to #94. When #94 lands, `parse_repo_id()` handles these ids and that paragraph should be deleted rather than left to rot. Worth a note on #94 itself.

Related: #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
