### PR TITLE
test: characterisation harness for git URL parsing and repo_id generation

### DIFF
--- a/tests/data/url_parsing_golden.json
+++ b/tests/data/url_parsing_golden.json
@@ -1,0 +1,291 @@
+{
+  "_README": [
+    "Characterisation golden for git URL parsing. Records CURRENT behaviour, bugs included -- it is not a statement of correctness.",
+    "Regenerate: UPDATE_URL_GOLDEN=1 pytest tests/test_url_parsing_characterisation.py",
+    "A diff here is the blast radius of a parser change. Review every line before committing it."
+  ],
+  "results": {
+    "": {
+      "parts": null,
+      "repo_id": null
+    },
+    "ftp://not-a-git-host/whatever": {
+      "parts": {
+        "org": "",
+        "remote": "not-a-git-host",
+        "remote_type": "ftp",
+        "repo": "whatever"
+      },
+      "repo_id": "not-a-git-host~~whatever"
+    },
+    "git@bitbucket.org:team/repo.git": {
+      "parts": {
+        "org": "team",
+        "remote": "bitbucket.org",
+        "remote_type": "ssh",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.org~team~repo"
+    },
+    "git@github.com:acme/svc.git": {
+      "parts": {
+        "org": "acme",
+        "remote": "github.com",
+        "remote_type": "ssh",
+        "repo": "svc"
+      },
+      "repo_id": "github.com~acme~svc"
+    },
+    "git@gitlab.com:group/subgroup/repo.git": {
+      "parts": {
+        "org": "group/subgroup",
+        "remote": "gitlab.com",
+        "remote_type": "ssh",
+        "repo": "repo"
+      },
+      "repo_id": "gitlab.com~group~~subgroup~repo"
+    },
+    "git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo": {
+      "parts": {
+        "org": "v3/myorg/MyProject",
+        "remote": "ssh.dev.azure.com",
+        "remote_type": "ssh",
+        "repo": "MyRepo"
+      },
+      "repo_id": "ssh.dev.azure.com~v3~~myorg~~MyProject~MyRepo"
+    },
+    "https://USERNAME@bitbucket.org/team/repo.git": {
+      "parts": {
+        "org": "team",
+        "remote": "bitbucket.org",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.org~team~repo"
+    },
+    "https://bitbucket.example.com/scm/PROJ/repo.git": {
+      "parts": {
+        "org": "PROJ",
+        "remote": "bitbucket.example.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.example.com~PROJ~repo"
+    },
+    "https://bitbucket.example.com/scm/~personal/repo.git": {
+      "parts": {
+        "org": "~personal",
+        "remote": "bitbucket.example.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.example.com~~personal~repo"
+    },
+    "https://bitbucket.org/team/repo.git": {
+      "parts": {
+        "org": "team",
+        "remote": "bitbucket.org",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.org~team~repo"
+    },
+    "https://dev.azure.com/myorg/My Project/_git/MyRepo": {
+      "parts": {
+        "org": "myorg-My Project",
+        "project": "My Project",
+        "remote": "dev.azure.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "dev.azure.com~myorg-My Project~MyRepo"
+    },
+    "https://dev.azure.com/myorg/MyProject/_git/MyRepo": {
+      "parts": {
+        "org": "myorg-MyProject",
+        "project": "MyProject",
+        "remote": "dev.azure.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "dev.azure.com~myorg-MyProject~MyRepo"
+    },
+    "https://dev.azure.com/myorg/MyProject/_git/MyRepo.git": {
+      "parts": {
+        "org": "myorg-MyProject",
+        "project": "MyProject",
+        "remote": "dev.azure.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "dev.azure.com~myorg-MyProject~MyRepo"
+    },
+    "https://example.com/a/b/c/d/e/f": {
+      "parts": {
+        "org": "a/b/c/d/e",
+        "remote": "example.com",
+        "remote_type": "https",
+        "repo": "f"
+      },
+      "repo_id": "example.com~a~~b~~c~~d~~e~f"
+    },
+    "https://example.com/single": {
+      "parts": {
+        "org": "",
+        "remote": "example.com",
+        "remote_type": "https",
+        "repo": "single"
+      },
+      "repo_id": "example.com~~single"
+    },
+    "https://github.com/Acme/Svc": {
+      "parts": {
+        "org": "Acme",
+        "remote": "github.com",
+        "remote_type": "https",
+        "repo": "Svc"
+      },
+      "repo_id": "github.com~Acme~Svc"
+    },
+    "https://github.com/acme/dashboard.js.git": {
+      "parts": {
+        "org": "acme",
+        "remote": "github.com",
+        "remote_type": "https",
+        "repo": "dashboard.js"
+      },
+      "repo_id": "github.com~acme~dashboard.js"
+    },
+    "https://github.com/acme/svc": {
+      "parts": {
+        "org": "acme",
+        "remote": "github.com",
+        "remote_type": "https",
+        "repo": "svc"
+      },
+      "repo_id": "github.com~acme~svc"
+    },
+    "https://github.com/acme/svc.git": {
+      "parts": {
+        "org": "acme",
+        "remote": "github.com",
+        "remote_type": "https",
+        "repo": "svc"
+      },
+      "repo_id": "github.com~acme~svc"
+    },
+    "https://gitlab.com/a/b/c/repo.git": {
+      "parts": {
+        "org": "a/b/c",
+        "remote": "gitlab.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "gitlab.com~a~~b~~c~repo"
+    },
+    "https://gitlab.com/group/repo.git": {
+      "parts": {
+        "org": "group",
+        "remote": "gitlab.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "gitlab.com~group~repo"
+    },
+    "https://gitlab.com/group/subgroup/repo.git": {
+      "parts": {
+        "org": "group/subgroup",
+        "remote": "gitlab.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "gitlab.com~group~~subgroup~repo"
+    },
+    "https://go.googlesource.com/oauth2": {
+      "parts": {
+        "org": "",
+        "remote": "go.googlesource.com",
+        "remote_type": "https",
+        "repo": "oauth2"
+      },
+      "repo_id": "go.googlesource.com~~oauth2"
+    },
+    "https://myorg.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo": {
+      "parts": {
+        "org": "DefaultCollection/MyProject/_git",
+        "remote": "myorg.visualstudio.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "myorg.visualstudio.com~DefaultCollection~~MyProject~~_git~MyRepo"
+    },
+    "https://myorg.visualstudio.com/MyProject/_git/MyRepo": {
+      "parts": {
+        "org": "MyProject",
+        "project": "MyProject",
+        "remote": "myorg.visualstudio.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "myorg.visualstudio.com~MyProject~MyRepo"
+    },
+    "https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo": {
+      "parts": {
+        "org": "myorg/MyProject/_git",
+        "remote": "myorg@dev.azure.com",
+        "remote_type": "https",
+        "repo": "MyRepo"
+      },
+      "repo_id": "myorg@dev.azure.com~myorg~~MyProject~~_git~MyRepo"
+    },
+    "https://user@bitbucket.example.com/scm/PROJ/repo.git": {
+      "parts": {
+        "org": "PROJ",
+        "remote": "user@bitbucket.example.com",
+        "remote_type": "https",
+        "repo": "repo"
+      },
+      "repo_id": "user@bitbucket.example.com~PROJ~repo"
+    },
+    "not a url at all": {
+      "parts": null,
+      "repo_id": null
+    },
+    "ssh://git@bitbucket.example.com/PROJ/repo.git": {
+      "parts": {
+        "org": "PROJ",
+        "remote": "bitbucket.example.com",
+        "remote_type": "ssh",
+        "repo": "repo"
+      },
+      "repo_id": "bitbucket.example.com~PROJ~repo"
+    },
+    "ssh://git@bitbucket.example.com:7999/PROJ/repo.git": {
+      "parts": {
+        "org": "",
+        "remote": "git@bitbucket.example.com:7999",
+        "remote_type": "ssh",
+        "repo": "PROJ/repo"
+      },
+      "repo_id": "git@bitbucket.example.com:7999~~PROJ/repo"
+    },
+    "ssh://git@github.com/acme/svc.git": {
+      "parts": {
+        "org": "acme",
+        "remote": "github.com",
+        "remote_type": "ssh",
+        "repo": "svc"
+      },
+      "repo_id": "github.com~acme~svc"
+    },
+    "ssh://git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo": {
+      "parts": {
+        "org": "myorg/MyProject",
+        "remote": "git@ssh.dev.azure.com:v3",
+        "remote_type": "ssh",
+        "repo": "MyRepo"
+      },
+      "repo_id": "git@ssh.dev.azure.com:v3~myorg~~MyProject~MyRepo"
+    }
+  }
+}

--- a/tests/test_url_parsing_characterisation.py
+++ b/tests/test_url_parsing_characterisation.py
@@ -1,0 +1,244 @@
+"""Characterisation tests for git URL parsing and repo_id generation.
+
+This suite does NOT assert correct behaviour. It pins **current** behaviour —
+bugs included — to a golden file so that any change to `parse_git_remote` or
+`generate_repo_id` produces a readable diff of exactly which URLs changed.
+
+Why: the parsers are being consolidated (#94) and `repo_id` case handling is
+under review (#147). Both change how ids are derived, and a changed id means
+existing `_repo_id` rows in a user's database stop matching. The risk worth
+guarding is not "is this URL parsed correctly" — it is "did this refactor
+silently change an id that already worked".
+
+Workflow
+--------
+1. Refactor the parser.
+2. Run this suite. It fails, listing every URL whose parse changed.
+3. Confirm each change is one you intended, then regenerate:
+
+       UPDATE_URL_GOLDEN=1 pytest tests/test_url_parsing_characterisation.py
+
+4. Commit the golden diff alongside the code change. The diff is the review
+   artefact — it shows the blast radius of a parser change in one place.
+
+Entries marked ``"known_wrong"`` capture output that is currently incorrect.
+They are deliberately pinned so a fix shows up as a diff rather than passing
+silently. Fixing one is expected to change its golden entry.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from kospex_git import KospexGit
+
+GOLDEN_PATH = Path(__file__).parent / "data" / "url_parsing_golden.json"
+
+# Corpus grouped by provider. Weighted towards Azure DevOps and Bitbucket:
+# those carry the most URL shapes, the most divergence between shapes for the
+# same repository, and the least existing test coverage.
+#
+# `known_wrong` marks output that is incorrect today. It is documentation, not
+# an assertion — the golden pins whatever the parser currently returns.
+CORPUS: list[dict] = [
+    # ---------------------------------------------------------------- GitHub
+    {"url": "https://github.com/acme/svc", "group": "github"},
+    {"url": "https://github.com/acme/svc.git", "group": "github"},
+    {"url": "git@github.com:acme/svc.git", "group": "github"},
+    {"url": "ssh://git@github.com/acme/svc.git", "group": "github"},
+    {"url": "https://github.com/acme/dashboard.js.git", "group": "github",
+     "note": "dotted repo name; regression guard for the scp-style fix"},
+    {"url": "https://github.com/Acme/Svc", "group": "github",
+     "note": "mixed case — pinned so #147 shows as a diff here"},
+
+    # ---------------------------------------------------------------- GitLab
+    {"url": "https://gitlab.com/group/repo.git", "group": "gitlab"},
+    {"url": "https://gitlab.com/group/subgroup/repo.git", "group": "gitlab",
+     "note": "nested group; org encodes '/' as '~~'"},
+    {"url": "https://gitlab.com/a/b/c/repo.git", "group": "gitlab",
+     "note": "two levels of subgroup"},
+    {"url": "git@gitlab.com:group/subgroup/repo.git", "group": "gitlab"},
+
+    # ----------------------------------------------------------- Azure DevOps
+    # Four URL shapes reach the same repository. They currently produce four
+    # different repo_ids -- the migration-relevant defect.
+    {"url": "https://dev.azure.com/myorg/MyProject/_git/MyRepo", "group": "ado",
+     "known_wrong": "org and project are joined with '-', which is ambiguous "
+                    "because '-' is legal in ADO org names"},
+    {"url": "https://dev.azure.com/myorg/MyProject/_git/MyRepo.git", "group": "ado"},
+    {"url": "https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo", "group": "ado",
+     "known_wrong": "this is ADO's own Clone-button URL. Username lands in the "
+                    "host and '_git' survives as a path segment"},
+    {"url": "https://myorg.visualstudio.com/MyProject/_git/MyRepo", "group": "ado",
+     "known_wrong": "legacy host form: the org lives in the hostname and is "
+                    "lost, so this yields a different id than dev.azure.com"},
+    {"url": "https://myorg.visualstudio.com/DefaultCollection/MyProject/_git/MyRepo",
+     "group": "ado", "known_wrong": "collection form is not recognised at all"},
+    {"url": "git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo", "group": "ado",
+     "known_wrong": "'v3' is taken as the org; host differs from the HTTPS form "
+                    "so the same repo gets yet another id"},
+    {"url": "ssh://git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo", "group": "ado",
+     "known_wrong": "ssh:// with a port-like segment; user survives in the host"},
+    {"url": "https://dev.azure.com/myorg/My Project/_git/MyRepo", "group": "ado",
+     "known_wrong": "space in the project name reaches the repo_id"},
+
+    # ------------------------------------------------------------- Bitbucket
+    {"url": "https://bitbucket.org/team/repo.git", "group": "bitbucket-cloud"},
+    {"url": "git@bitbucket.org:team/repo.git", "group": "bitbucket-cloud"},
+    {"url": "https://USERNAME@bitbucket.org/team/repo.git", "group": "bitbucket-cloud",
+     "note": "cloud clone URLs embed the username"},
+    {"url": "https://bitbucket.example.com/scm/PROJ/repo.git", "group": "bitbucket-server",
+     "note": "'/scm/' is a Bitbucket Server URL convention and is correctly "
+             "dropped; project keys are uppercase by convention"},
+    {"url": "https://user@bitbucket.example.com/scm/PROJ/repo.git",
+     "group": "bitbucket-server",
+     "known_wrong": "only a literal 'git@' is stripped, so other usernames "
+                    "remain in the host"},
+    {"url": "ssh://git@bitbucket.example.com:7999/PROJ/repo.git",
+     "group": "bitbucket-server",
+     "known_wrong": "#160 — Bitbucket Server's default SSH URL. Port lands in "
+                    "the host, org is empty, repo keeps a '/'. The empty org "
+                    "emits a '~~' that collides with the nested-group encoding"},
+    {"url": "ssh://git@bitbucket.example.com/PROJ/repo.git", "group": "bitbucket-server",
+     "note": "portless ssh:// parses correctly — isolates the port as the cause"},
+    {"url": "https://bitbucket.example.com/scm/~personal/repo.git",
+     "group": "bitbucket-server",
+     "known_wrong": "personal repos are '~username'; the leading '~' produces a "
+                    "'~~' indistinguishable from the nested-group encoding"},
+
+    # ------------------------------------------------------------ Google / Go
+    {"url": "https://go.googlesource.com/oauth2", "group": "google"},
+
+    # ----------------------------------------------------------- Should reject
+    # Nothing here is a git remote. Every one currently returns a populated
+    # dict rather than None (#160).
+    {"url": "ftp://not-a-git-host/whatever", "group": "reject",
+     "known_wrong": "#160 — non-git scheme is accepted"},
+    {"url": "https://example.com/single", "group": "reject",
+     "known_wrong": "#160 — single path segment, no org, is accepted"},
+    {"url": "https://example.com/a/b/c/d/e/f", "group": "reject",
+     "known_wrong": "#160 — arbitrarily deep path is accepted"},
+    {"url": "not a url at all", "group": "reject"},
+    {"url": "", "group": "reject"},
+]
+
+
+def _capture(url: str) -> dict:
+    """Current parser output for one URL. Never raises — a crash is a result."""
+    try:
+        parts = KospexGit.parse_git_remote(url)
+    except Exception as exc:  # noqa: BLE001 - capturing failure is the point
+        return {"parts": None, "repo_id": None, "error": f"{type(exc).__name__}: {exc}"}
+
+    if not parts:
+        return {"parts": None, "repo_id": None}
+
+    try:
+        repo_id = KospexGit.generate_repo_id(
+            parts.get("remote"), parts.get("org"), parts.get("repo")
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {"parts": parts, "repo_id": None,
+                "error": f"{type(exc).__name__}: {exc}"}
+
+    return {"parts": parts, "repo_id": repo_id}
+
+
+def _capture_all() -> dict:
+    return {entry["url"]: _capture(entry["url"]) for entry in CORPUS}
+
+
+def _load_golden() -> dict:
+    if not GOLDEN_PATH.is_file():
+        pytest.fail(
+            f"Golden file missing: {GOLDEN_PATH}\n"
+            "Generate it with:  UPDATE_URL_GOLDEN=1 pytest "
+            "tests/test_url_parsing_characterisation.py"
+        )
+    return json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def _write_golden(captured: dict) -> None:
+    GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "_README": [
+            "Characterisation golden for git URL parsing. Records CURRENT "
+            "behaviour, bugs included -- it is not a statement of correctness.",
+            "Regenerate: UPDATE_URL_GOLDEN=1 pytest "
+            "tests/test_url_parsing_characterisation.py",
+            "A diff here is the blast radius of a parser change. Review every "
+            "line before committing it.",
+        ],
+        "results": captured,
+    }
+    GOLDEN_PATH.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_url_parsing_matches_golden() -> None:
+    """Every URL in the corpus parses exactly as the golden file records."""
+    captured = _capture_all()
+
+    if os.environ.get("UPDATE_URL_GOLDEN"):
+        _write_golden(captured)
+        pytest.skip("golden regenerated — re-run without UPDATE_URL_GOLDEN to verify")
+
+    golden = _load_golden()["results"]
+
+    changed = []
+    for url, now in captured.items():
+        before = golden.get(url, "<not in golden>")
+        if before != now:
+            changed.append(f"  {url}\n     was: {before}\n     now: {now}")
+
+    dropped = sorted(set(golden) - set(captured))
+
+    problems = []
+    if changed:
+        problems.append(
+            f"{len(changed)} URL(s) parse differently than the golden records:\n"
+            + "\n".join(changed)
+        )
+    if dropped:
+        problems.append(
+            "URL(s) in the golden but no longer in CORPUS: " + ", ".join(dropped)
+        )
+
+    assert not problems, (
+        "\n\n".join(problems)
+        + "\n\nIf every change above is intended, regenerate the golden:\n"
+        "  UPDATE_URL_GOLDEN=1 pytest tests/test_url_parsing_characterisation.py"
+    )
+
+
+def test_corpus_and_golden_cover_the_same_urls() -> None:
+    """Guards against a URL being dropped from the corpus without notice."""
+    golden = _load_golden()["results"]
+    assert sorted(golden) == sorted(e["url"] for e in CORPUS)
+
+
+def test_same_ado_repo_currently_yields_multiple_ids() -> None:
+    """Pins the migration-relevant ADO defect as an explicit, named fact.
+
+    Four clone URL shapes address one repository (myorg / MyProject / MyRepo).
+    They currently produce different repo_ids, so one repo can be recorded
+    several times. When the ADO parsing is fixed this test should fail and be
+    rewritten to assert they *agree*.
+    """
+    same_repo = [
+        "https://dev.azure.com/myorg/MyProject/_git/MyRepo",
+        "https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo",
+        "https://myorg.visualstudio.com/MyProject/_git/MyRepo",
+        "git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo",
+    ]
+    ids = {_capture(u)["repo_id"] for u in same_repo}
+    assert len(ids) > 1, (
+        "ADO URL shapes now agree on a repo_id. That is the desired outcome — "
+        "replace this test with one asserting they are all equal."
+    )


### PR DESCRIPTION
Tests only — no source change. Refs #94, #147, #160.

Groundwork so the parser work is **diffable**. `parse_git_remote` and `generate_repo_id` are about to change under #94 (parser consolidation), #147 (`repo_id` case) and #160 (the never-rejecting fallback). Each of those changes how ids are derived, and **a changed id means existing `_repo_id` rows in a user's database stop matching**.

This suite pins current output — bugs included — for a 33-URL corpus. It is not a statement of correctness. The question it answers is not *"is this URL parsed correctly"* but *"did this refactor silently change an id that already worked"*.

## Workflow

```bash
# after a parser change, this fails and lists exactly which URLs moved
pytest tests/test_url_parsing_characterisation.py

# once every change is confirmed intentional
UPDATE_URL_GOLDEN=1 pytest tests/test_url_parsing_characterisation.py
```

The golden diff is then the review artefact — the blast radius of a parser change, in one file.

## Verified that it actually catches things

Simulating the #160 fix (tightening the Google/Go catch-all) produced a precise two-URL diff and nothing else:

```
2 URL(s) parse differently than the golden records:
  ssh://git@bitbucket.example.com:7999/PROJ/repo.git
     was: {... 'org': '', 'remote': 'git@bitbucket.example.com:7999', 'repo': 'PROJ/repo'}
     now: {'parts': None, 'repo_id': None}
  ftp://not-a-git-host/whatever
     was: {... 'repo_id': 'not-a-git-host~~whatever'}
     now: {'parts': None, 'repo_id': None}
```

## Corpus

Weighted to **Azure DevOps and Bitbucket** — the most URL shapes, the most divergence between shapes, and the least existing coverage. `test_kgit.py` already covers GitHub and scp-style SSH well; those are included as regression guards rather than the focus.

Entries carry a `known_wrong` note where output is currently incorrect, so the corpus doubles as an inventory. Two worth calling out:

**Four ADO URL shapes address one repository and produce four different ids.** Pinned as its own named test, `test_same_ado_repo_currently_yields_multiple_ids`:

| clone URL | repo_id |
|---|---|
| `dev.azure.com/myorg/MyProject/_git/MyRepo` | `dev.azure.com~myorg-MyProject~MyRepo` |
| `myorg@dev.azure.com/...` — **ADO's own Clone-button URL** | `myorg@dev.azure.com~myorg~~MyProject~~_git~MyRepo` |
| `myorg.visualstudio.com/MyProject/_git/MyRepo` — legacy | `myorg.visualstudio.com~MyProject~MyRepo` |
| `git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo` | `ssh.dev.azure.com~v3~~myorg~~MyProject~MyRepo` |

That test asserts the ids currently *disagree*. When ADO parsing is fixed it will fail, and should be rewritten to assert they agree.

**Three separate sources of a spurious `~~`**, which matters because `~~` is the nested-group encoding a decoder is about to be taught to read (#94 Step 1):

- an empty org (#160)
- Bitbucket personal repos, `/scm/~username/repo.git`
- legitimate GitLab subgroups — the only correct one

## Notes

- 539 passed, 75 skipped locally — no existing test affected.
- The golden is committed. Regenerating is a deliberate act with a reviewable diff, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
