### PR TITLE
fix(git): make parse_git_remote reject, and strip credentials/port from the host

### DIFF
--- a/src/kospex_git.py
+++ b/src/kospex_git.py
@@ -222,14 +222,49 @@ class KospexGit:
         url (str): The URL to extract information from.
 
         Returns:
-        dict: A dictionary containing the remote, org, repo, and remote_type.
+        dict: A dictionary containing the remote, org, repo, and remote_type,
+        or None if the URL is not a recognisable git remote.
         """
+        if not url or not isinstance(url, str):
+            return None
+
+        # Normalise scheme-based URLs before any provider rule sees them.
+        # urlparse().hostname drops embedded credentials and the port for
+        # free -- without this, 'ssh://git@host:7999/PROJ/repo.git' keeps
+        # 'git@host:7999' as the server, so the same repository cloned over
+        # SSH and HTTPS produces two different repo_ids.
+        # scp-style ('git@host:org/repo.git') has no '://' and is handled
+        # further down by parse_ssh_git_url, so leave it untouched.
+        if "://" in url:
+            try:
+                _p = urlparse(url.strip())
+            except ValueError:
+                return None
+            if _p.scheme.lower() not in ("http", "https", "ssh", "git"):
+                return None  # not a git transport
+            if not _p.hostname:
+                return None
+            if _p.username or _p.port:
+                url = f"{_p.scheme}://{_p.hostname}{_p.path}"
+
         # Regular expression to match the default pattern
         pattern = r"^(https?|git|ssh)\:\/\/(?:[\w.-]+@)?([\w.-]+)\/([\w.-]+)\/([\w.-]+)(?:\.git)?$"
         match = re.match(pattern, url)
-        # There are some Go libraries which use a different URL format from Google
-        # https://go.googlesource.com/oauth2
-        g_pattern = r"(?P<protocol>^\w+)://(?P<domain>[^\/?#]+)/(?P<directory>.*)"
+        # Gerrit hosts under *.googlesource.com (go., chromium., android.,
+        # boringssl., ...) allow a *single-segment* project path, which has no
+        # org: https://go.googlesource.com/oauth2
+        # Multi-segment paths there need no special case -- the generic nested
+        # rule below already encodes them correctly.
+        # This pattern is deliberately host-scoped. It used to be
+        # '(?P<domain>[^\/?#]+)/(?P<directory>.*)', which matched any
+        # scheme://host/path and made parse_git_remote incapable of ever
+        # returning None -- so junk was silently given a plausible repo_id
+        # instead of being rejected.
+        g_pattern = (
+            r"(?P<protocol>^https?)://"
+            r"(?P<domain>[\w.-]+\.googlesource\.com)/"
+            r"(?P<directory>[\w.-]+?)(?:\.git)?/?$"
+        )
         google_match = re.match(g_pattern, url)
 
         # gitlab_pattern = r"(?P<protocol>^https?://)" \

--- a/tests/data/url_parsing_golden.json
+++ b/tests/data/url_parsing_golden.json
@@ -10,13 +10,8 @@
       "repo_id": null
     },
     "ftp://not-a-git-host/whatever": {
-      "parts": {
-        "org": "",
-        "remote": "not-a-git-host",
-        "remote_type": "ftp",
-        "repo": "whatever"
-      },
-      "repo_id": "not-a-git-host~~whatever"
+      "parts": null,
+      "repo_id": null
     },
     "git@bitbucket.org:team/repo.git": {
       "parts": {
@@ -63,6 +58,15 @@
       },
       "repo_id": "bitbucket.org~team~repo"
     },
+    "https://android.googlesource.com/platform/frameworks/base": {
+      "parts": {
+        "org": "platform/frameworks",
+        "remote": "android.googlesource.com",
+        "remote_type": "https",
+        "repo": "base"
+      },
+      "repo_id": "android.googlesource.com~platform~~frameworks~base"
+    },
     "https://bitbucket.example.com/scm/PROJ/repo.git": {
       "parts": {
         "org": "PROJ",
@@ -89,6 +93,24 @@
         "repo": "repo"
       },
       "repo_id": "bitbucket.org~team~repo"
+    },
+    "https://boringssl.googlesource.com/boringssl": {
+      "parts": {
+        "org": "",
+        "remote": "boringssl.googlesource.com",
+        "remote_type": "https",
+        "repo": "boringssl"
+      },
+      "repo_id": "boringssl.googlesource.com~~boringssl"
+    },
+    "https://chromium.googlesource.com/chromium/src": {
+      "parts": {
+        "org": "chromium",
+        "remote": "chromium.googlesource.com",
+        "remote_type": "https",
+        "repo": "src"
+      },
+      "repo_id": "chromium.googlesource.com~chromium~src"
     },
     "https://dev.azure.com/myorg/My Project/_git/MyRepo": {
       "parts": {
@@ -130,13 +152,8 @@
       "repo_id": "example.com~a~~b~~c~~d~~e~f"
     },
     "https://example.com/single": {
-      "parts": {
-        "org": "",
-        "remote": "example.com",
-        "remote_type": "https",
-        "repo": "single"
-      },
-      "repo_id": "example.com~~single"
+      "parts": null,
+      "repo_id": null
     },
     "https://github.com/Acme/Svc": {
       "parts": {
@@ -231,21 +248,22 @@
     },
     "https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo": {
       "parts": {
-        "org": "myorg/MyProject/_git",
-        "remote": "myorg@dev.azure.com",
+        "org": "myorg-MyProject",
+        "project": "MyProject",
+        "remote": "dev.azure.com",
         "remote_type": "https",
         "repo": "MyRepo"
       },
-      "repo_id": "myorg@dev.azure.com~myorg~~MyProject~~_git~MyRepo"
+      "repo_id": "dev.azure.com~myorg-MyProject~MyRepo"
     },
     "https://user@bitbucket.example.com/scm/PROJ/repo.git": {
       "parts": {
         "org": "PROJ",
-        "remote": "user@bitbucket.example.com",
+        "remote": "bitbucket.example.com",
         "remote_type": "https",
         "repo": "repo"
       },
-      "repo_id": "user@bitbucket.example.com~PROJ~repo"
+      "repo_id": "bitbucket.example.com~PROJ~repo"
     },
     "not a url at all": {
       "parts": null,
@@ -262,12 +280,12 @@
     },
     "ssh://git@bitbucket.example.com:7999/PROJ/repo.git": {
       "parts": {
-        "org": "",
-        "remote": "git@bitbucket.example.com:7999",
+        "org": "PROJ",
+        "remote": "bitbucket.example.com",
         "remote_type": "ssh",
-        "repo": "PROJ/repo"
+        "repo": "repo"
       },
-      "repo_id": "git@bitbucket.example.com:7999~~PROJ/repo"
+      "repo_id": "bitbucket.example.com~PROJ~repo"
     },
     "ssh://git@github.com/acme/svc.git": {
       "parts": {
@@ -281,11 +299,11 @@
     "ssh://git@ssh.dev.azure.com:v3/myorg/MyProject/MyRepo": {
       "parts": {
         "org": "myorg/MyProject",
-        "remote": "git@ssh.dev.azure.com:v3",
+        "remote": "ssh.dev.azure.com",
         "remote_type": "ssh",
         "repo": "MyRepo"
       },
-      "repo_id": "git@ssh.dev.azure.com:v3~myorg~~MyProject~MyRepo"
+      "repo_id": "ssh.dev.azure.com~myorg~~MyProject~MyRepo"
     }
   }
 }

--- a/tests/test_kgit.py
+++ b/tests/test_kgit.py
@@ -104,3 +104,63 @@ def test_extract_git_url_parts_delegates_to_parse_git_remote(url):
     """
     kg = KospexGit()
     assert kg.extract_git_url_parts(url) == KospexGit.parse_git_remote(url)
+
+
+def test_parse_git_remote_rejects_non_git_schemes():
+    """A non-git transport is not a remote. #160."""
+    assert KospexGit.parse_git_remote("ftp://not-a-git-host/whatever") is None
+
+
+def test_parse_git_remote_rejects_org_less_paths_on_unknown_hosts():
+    """A single path segment has no org, so it is not a usable remote. #160.
+
+    Gerrit hosts under *.googlesource.com are the deliberate exception -- see
+    test_parse_git_remote_allows_single_segment_googlesource.
+    """
+    assert KospexGit.parse_git_remote("https://example.com/single") is None
+
+
+def test_parse_git_remote_rejects_junk():
+    """#160 -- the old catch-all meant this returned a populated dict."""
+    for junk in ["not a url at all", "", None]:
+        assert KospexGit.parse_git_remote(junk) is None
+
+
+def test_parse_git_remote_allows_single_segment_googlesource():
+    """Gerrit projects may be a single segment with no org. #160."""
+    parts = KospexGit.parse_git_remote("https://go.googlesource.com/oauth2")
+    assert parts is not None
+    assert parts["remote"] == "go.googlesource.com"
+    assert parts["org"] == ""
+    assert parts["repo"] == "oauth2"
+
+
+def test_credentials_and_port_are_stripped_from_the_host():
+    """The same repo over SSH and HTTPS must yield one repo_id. #160.
+
+    Bitbucket Server's default SSH URL embeds git@ and port 7999; previously
+    both landed in the server segment, so an SSH clone and an HTTPS clone of
+    one repository produced two different repo_ids.
+    """
+    over_ssh = KospexGit.parse_git_remote(
+        "ssh://git@bitbucket.example.com:7999/PROJ/repo.git")
+    over_https = KospexGit.parse_git_remote(
+        "https://bitbucket.example.com/scm/PROJ/repo.git")
+
+    assert over_ssh["remote"] == "bitbucket.example.com"
+    assert "/" not in over_ssh["repo"]
+    assert KospexGit.generate_repo_id(**{k: over_ssh[k] for k in ("remote", "org", "repo")}) == \
+           KospexGit.generate_repo_id(**{k: over_https[k] for k in ("remote", "org", "repo")})
+
+
+def test_ado_clone_button_url_matches_the_plain_url():
+    """ADO's Clone button embeds the org as a username. #160.
+
+    Both forms address one repository and must produce one repo_id.
+    """
+    def rid(url):
+        p = KospexGit.parse_git_remote(url)
+        return KospexGit.generate_repo_id(p["remote"], p["org"], p["repo"])
+
+    assert rid("https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo") == \
+           rid("https://dev.azure.com/myorg/MyProject/_git/MyRepo")

--- a/tests/test_url_parsing_characterisation.py
+++ b/tests/test_url_parsing_characterisation.py
@@ -100,18 +100,24 @@ CORPUS: list[dict] = [
                     "remain in the host"},
     {"url": "ssh://git@bitbucket.example.com:7999/PROJ/repo.git",
      "group": "bitbucket-server",
-     "known_wrong": "#160 — Bitbucket Server's default SSH URL. Port lands in "
-                    "the host, org is empty, repo keeps a '/'. The empty org "
-                    "emits a '~~' that collides with the nested-group encoding"},
+     "known_wrong": "#160 — Bitbucket Server's default SSH URL. Credentials "
+                    "and port land in the host and the repo keeps a '/', so the "
+                    "same repo over HTTPS and SSH gets two different ids"},
     {"url": "ssh://git@bitbucket.example.com/PROJ/repo.git", "group": "bitbucket-server",
      "note": "portless ssh:// parses correctly — isolates the port as the cause"},
     {"url": "https://bitbucket.example.com/scm/~personal/repo.git",
      "group": "bitbucket-server",
-     "known_wrong": "personal repos are '~username'; the leading '~' produces a "
-                    "'~~' indistinguishable from the nested-group encoding"},
+     "note": "personal repos are '~username'. The resulting '~~' round-trips "
+             "correctly; it only collides if a *repo* name contains a '~'"},
 
     # ------------------------------------------------------------ Google / Go
-    {"url": "https://go.googlesource.com/oauth2", "group": "google"},
+    {"url": "https://go.googlesource.com/oauth2", "group": "google",
+     "note": "single-segment Gerrit project; org is empty by design"},
+    {"url": "https://chromium.googlesource.com/chromium/src", "group": "google",
+     "note": "multi-segment already parses correctly via the generic rule"},
+    {"url": "https://android.googlesource.com/platform/frameworks/base",
+     "group": "google", "note": "deep path uses the nested-group encoding"},
+    {"url": "https://boringssl.googlesource.com/boringssl", "group": "google"},
 
     # ----------------------------------------------------------- Should reject
     # Nothing here is a git remote. Every one currently returns a populated


### PR DESCRIPTION
Closes #160. First change to land against the characterisation harness (#161), so the golden diff is the review artefact.

## What was wrong

`parse_git_remote` had **no failure mode**. The Google/Go branch matched `(?P<domain>[^\/?#]+)/(?P<directory>.*)` — any `scheme://host/path` — hardcoded `org: ""` and returned a populated dict. So `ftp://not-a-git-host/whatever` "parsed", and every `if not parts:` guard in the codebase was dead code.

## Two changes

**1. Normalise scheme-based URLs before any provider rule sees them.** `urlparse().hostname` drops embedded credentials and the port for free. Without it, `ssh://git@host:7999/PROJ/repo.git` kept `git@host:7999` as the server. scp-style URLs have no `://` and are left for `parse_ssh_git_url`.

**2. Scope the Gerrit branch to `*.googlesource.com`** with a single path segment, instead of matching everything. Multi-segment googlesource paths need no special case — the generic nested rule already handles `chromium/src` and `platform/frameworks/base` correctly. Anything unrecognised now returns `None`.

## The payoff: URL families that now agree

**Bitbucket Server** — SSH and HTTPS clone URLs for one repository:

```
ssh://git@bitbucket.example.com:7999/PROJ/repo.git
https://bitbucket.example.com/scm/PROJ/repo.git
  both -> bitbucket.example.com~PROJ~repo
```

**Azure DevOps** — the Clone-button URL (which embeds the org as a username) and the plain URL:

```
https://myorg@dev.azure.com/myorg/MyProject/_git/MyRepo
https://dev.azure.com/myorg/MyProject/_git/MyRepo
  both -> dev.azure.com~myorg-MyProject~MyRepo
```

That takes ADO from **4 distinct ids for one repository down to 3**. The legacy `visualstudio.com` form (org lives in the hostname) and `ssh.dev.azure.com:v3` form still disagree — out of scope here, and worth their own issue given the migration impact.

## Golden diff — 6 URLs, all intended

| URL | was | now |
|---|---|---|
| `ssh://git@bitbucket.example.com:7999/PROJ/repo.git` | `git@bitbucket.example.com:7999~~PROJ/repo` | `bitbucket.example.com~PROJ~repo` |
| `https://user@bitbucket.example.com/scm/PROJ/repo.git` | `user@bitbucket.example.com~PROJ~repo` | `bitbucket.example.com~PROJ~repo` |
| `https://myorg@dev.azure.com/...` | `myorg@dev.azure.com~myorg~~MyProject~~_git~MyRepo` | `dev.azure.com~myorg-MyProject~MyRepo` |
| `ssh://git@ssh.dev.azure.com:v3/...` | `git@ssh.dev.azure.com:v3~myorg~~MyProject~MyRepo` | `ssh.dev.azure.com~myorg~~MyProject~MyRepo` |
| `ftp://not-a-git-host/whatever` | `not-a-git-host~~whatever` | `None` |
| `https://example.com/single` | `example.com~~single` | `None` |

Nothing else moved — GitHub, GitLab (flat and nested), Bitbucket Cloud, ADO HTTPS and all three googlesource shapes are byte-identical.

## Also in here

**A correction to two annotations added in #161.** They claimed an empty org emits a `~~` that collides with the nested-group encoding. **It does not** — empty org round-trips correctly under the corrected decoder, and the only real collision needs a `~` inside a *repo* name, which Bitbucket's `~username` convention doesn't produce. I asserted that without testing the decoder; corrected here and on #160.

**Six explicit intent tests** in `test_kgit.py` alongside the golden. The golden pins behaviour; these state intent, so a careless `UPDATE_URL_GOLDEN=1` can't silently un-fix this.

Full suite: **545 passed, 75 skipped** (was 539/75 — the six new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
