### PR TITLE
fix(sync): safe delimiter, unquoted paths, and merge-only content

### DIFF
--- a/changes/202608-merge-content-and-commit-delimiter.md
+++ b/changes/202608-merge-content-and-commit-delimiter.md
@@ -1,0 +1,156 @@
+# Commit ingest: safe delimiter, unquoted paths, and merge-only content
+
+Closes #163, #116 and #121 — three defects in one command, `git log` at
+`kospex_core.py:334`.
+
+## Overview
+
+The commits/commit_files ingest had three problems in the same place:
+
+1. It split git's output on `#`, which is legal in an author or committer email.
+   One `#` shifted every later field and the last field silently absorbed the
+   remainder, corrupting `author_email` — the primary developer identity key.
+2. It let git quote non-ASCII paths, so `"caf\303\251.py"` was stored instead of
+   `café.py` and never matched anything else in kospex.
+3. It recorded nothing at all for content that a merge introduced but that
+   exists in none of its parents.
+
+## 1. Delimiter (#163)
+
+```python
+# was
+"--pretty=format:%H#%aI#%cI#%aN#%aE#%cN#%cE"        line.split("#", 6)
+# now
+COMMIT_LOG_FORMAT   # %H\x1f%aI\x1f...\x1f%P        line.split("\x1f")
+```
+
+ASCII Unit Separator, because git rejects control characters in name and email
+fields where it permits `#`. Real data hits this: `NixOS/nixpkgs` has 97 commits
+authored `git#v1@kaction.cc`, which today parse as:
+
+```
+author_email     = 'git'                            <- truncated
+committer_name   = 'v1@kaction.cc'                  <- an email in the name field
+committer_email  = 'KAction#git#v1@kaction.cc'      <- absorbed the remainder
+```
+
+The parser now asserts the field count instead of unpacking optimistically. A
+silent shift is what kept this invisible — and querying the DB for `#` returns
+zero rows, because the parse consumed the delimiter before the insert.
+
+## 2. Unquoted paths (#116)
+
+All walks run with `-c core.quotePath=false`. `file_metadata.committer_when` is
+keyed on `commit_files.file_path` via `latest_commit_file_map()`, so a quoted
+path there could never match the path panopticas walked, leaving `committer_when`
+NULL and the row keyed on repo HEAD.
+
+## 3. Merge content (#121)
+
+`git log --numstat` reports zero files for a merge. **That is correct and is
+preserved.** A merge that only combines branches authored nothing, and
+attributing files to it double-counts work already credited to the branch
+commits. The main walk is unchanged — no `--diff-merges`.
+
+The gap is an *evil merge* — git's own glossary term for "a merge that
+introduces changes that do not appear in any parent": a conflict resolution, or
+a file added while merging. That content was recorded nowhere.
+
+### Why it needs two extra walks
+
+No single git invocation can both filter to combined-diff files and report
+counts. Tested against a clean merge:
+
+```
+--name-only --diff-merges=combined   ->  (nothing)      correct
+--numstat   --diff-merges=combined   ->  1  1  b.txt    wrong
+git show -c / --cc / -m --numstat    ->  1  1  b.txt    wrong
+git diff-tree -c / --cc --numstat    ->  1  1  b.txt    wrong
+```
+
+`--numstat` has no combined representation and silently degrades to first-parent
+— byte-identical to `--diff-merges=first-parent`, verified programmatically. So:
+
+| walk | command | runs |
+|---|---|---|
+| main | `--numstat` *(unchanged)* | always |
+| mask | `--name-only --diff-merges=combined` | always — detection |
+| counts | `--numstat -m` | **only if the mask found something** |
+
+### Why the naive fix would have been bad
+
+Adding `--diff-merges=combined` to the numstat command — the shape originally
+proposed on #121 — inflates every merge:
+
+| repo | rows today | this fix adds | naive fix would add |
+|---|---:|---:|---:|
+| kospex | 1,667 | **0** | 215 (12.9%) |
+| click | 5,225 | **442** (8.5%) | 4,765 (91.2%) |
+| pydantic | 25,858 | **276** (1.1%) | 418 |
+| react | 131,811 | **838** (0.6%) | 22,810 (17.3%) |
+
+### Counts come from the closest parent, not the first
+
+`-m` emits one numstat block per parent in a single walk, so the smallest change
+for a path is its diff against the nearest parent. That isolates what the merger
+actually typed; first-parent counts also include the branch's own work:
+
+```
+src/click/shell_completion.py
+  first-parent       :  40+ / 16-     <- includes the branch's work
+  closest parent     :   2+ /  3-     <- what the merger typed
+```
+
+Across evil-merge rows: click 33% of rows differ, total churn 8,469 -> 3,177
+(2.7x over-credit avoided); react 29%, 40,168 -> 30,971. This matters for
+key-person and bus-factor analysis, where a conflict resolution is real work by
+the person with the deepest knowledge of the subsystem — currently invisible.
+
+### Cost
+
+The counting walk is skipped when no merge carries content of its own, so a
+clean-merge repo pays only for detection:
+
+| | kospex (0 evil merges) | click (259) | react (357) |
+|---|---:|---:|---:|
+| main walk (unchanged) | 108 ms | 334 ms | 9,186 ms |
+| mask | 23 ms | 92 ms | 1,850 ms |
+| counts | *skipped* | 894 ms | 13,589 ms |
+
+## `parents` is now populated
+
+`[parents] INTEGER` has been declared since the Mergestat-derived schema and was
+never written — 0 of 254,997 rows. `%P` fills it, so **no migration**.
+
+Stored as a count, since merge detection only asks `parents > 1`. Never `== 2`:
+`NixOS/nixpkgs` has 12 octopus merges, one with **16 parents**.
+
+## Backfill
+
+All three fixes apply to newly-synced commits. Commit sync is incremental
+(`--since` the last recorded commit), so existing rows keep their mangled emails,
+quoted paths and NULL `parents` until affected repos are re-synced with a reset
+window. The 34 quoted paths in `commit_files` also change primary key when
+unquoted, so a re-sync adds the unquoted row rather than replacing the quoted
+one — those need deleting, not just re-syncing.
+
+## Files changed
+
+- `src/kospex_core.py` — `COMMIT_LOG_FORMAT`, `parse_commit_log()`,
+  `merge_file_rows()` and helpers; `sync_repo()` rewired
+- `tests/test_commit_log_parsing.py` — 13 tests
+- `tests/test_merge_file_rows.py` — 7 tests
+
+## Verification
+
+Beyond the unit tests, an end-to-end `sync_repo()` against a throwaway repo and
+DB confirms, through the real code path:
+
+```
+author_email intact      : 'git#v1@kaction.cc'
+committer_name           : 'KAction'
+clean merge parents      : 2       nulls remaining: 0
+clean merge file rows    : 0       <- the invariant
+evil merge paths         : ['café.py', 'shared.txt']
+quoted paths in DB       : 0
+```

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -107,6 +107,224 @@ def needs_metadata_rebuild(recorded, current, force=False):
     return False, "up to date"
 
 
+# Field separator for the commit log format. ASCII Unit Separator, because git
+# rejects control characters in name and email fields. The previous delimiter
+# was "#", which is legal in both — one "#" in an author email shifted every
+# later field and the last field silently absorbed the remainder, corrupting
+# author_email (the primary developer identity key) with no error. See #163.
+COMMIT_LOG_SEP = "\x1f"
+
+COMMIT_LOG_FIELDS = (
+    "hash",
+    "author_when",
+    "committer_when",
+    "author_name",
+    "author_email",
+    "committer_name",
+    "committer_email",
+    "parents",
+)
+
+COMMIT_LOG_FORMAT = COMMIT_LOG_SEP.join(
+    ("%H", "%aI", "%cI", "%aN", "%aE", "%cN", "%cE", "%P")
+)
+
+
+def parse_commit_log(output):
+    """Parse `git log --pretty=format:COMMIT_LOG_FORMAT --numstat` output.
+
+    Returns a list of commit dicts. Each carries the COMMIT_LOG_FIELDS plus
+    "filenames": a list of {file_path, path_change, additions, deletions}.
+
+    "parents" is a count, not the hashes: merge detection only ever asks
+    `parents > 1`. Never `== 2` — octopus merges are real (nixpkgs has 12, one
+    with 16 parents).
+
+    A header line is identified by the separator rather than by a character
+    that can occur in the data, and the field count is asserted rather than
+    unpacked optimistically. Silently absorbing overflow is exactly what kept
+    the "#" delimiter bug (#163) invisible.
+    """
+    commits = []
+    commit = None
+
+    for line in output.split("\n"):
+        if not line:
+            continue
+
+        if COMMIT_LOG_SEP in line:
+            parts = line.split(COMMIT_LOG_SEP)
+            if len(parts) != len(COMMIT_LOG_FIELDS):
+                raise ValueError(
+                    f"expected {len(COMMIT_LOG_FIELDS)} fields in commit log "
+                    f"record, got {len(parts)}: {line!r}"
+                )
+
+            commit = dict(zip(COMMIT_LOG_FIELDS, parts))
+            commit["parents"] = len(commit["parents"].split())
+            commit["author_email"] = commit["author_email"].lower()
+            commit["committer_email"] = commit["committer_email"].lower()
+            commit["filenames"] = []
+            commits.append(commit)
+            continue
+
+        fields = line.split("\t")
+        if len(fields) == 3 and commit is not None:
+            additions, deletions, filename = fields
+            # A git rename arrives as "old => new" (or "{a => b}/c"); the
+            # existing helper unpacks it to the post-rename path.
+            path_change = filename if "=>" in filename else None
+            file_path = (
+                KospexUtils.parse_git_rename_event(filename)
+                if path_change
+                else filename
+            )
+            commit["filenames"].append(
+                {
+                    "file_path": file_path,
+                    "path_change": path_change,
+                    # Binary files report "-" rather than a count.
+                    "additions": int(additions) if additions != "-" else 0,
+                    "deletions": int(deletions) if deletions != "-" else 0,
+                }
+            )
+
+    return commits
+
+
+def _git_log(repo_dir, *args, window=None):
+    """Run `git log` in repo_dir with core.quotePath disabled.
+
+    quotePath=false stops git emitting "caf\\303\\251.py" for non-ASCII paths,
+    which never matched the path anything else in kospex produced (#116).
+
+    Returns "" if git fails — a repo with no commits exits non-zero.
+    """
+    cmd = ["git", "-C", str(repo_dir), "-c", "core.quotePath=false", "log", *args]
+    cmd += list(window or [])
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=True
+        ).stdout
+    except (subprocess.CalledProcessError, OSError) as exc:
+        log.debug("git log failed in %s: %s", repo_dir, exc)
+        return ""
+
+
+def _merge_content_mask(repo_dir, window=None):
+    """{merge_hash: {path, ...}} for files a merge changed relative to EVERY parent.
+
+    --diff-merges=combined is the only form that filters this way; --numstat
+    silently degrades to first-parent, which would attribute the whole merged
+    branch to the merge.
+    """
+    out = _git_log(
+        repo_dir,
+        f"--pretty=format:{COMMIT_LOG_SEP}%H{COMMIT_LOG_SEP}%P",
+        "--name-only",
+        "--diff-merges=combined",
+        window=window,
+    )
+
+    mask = {}
+    current = None
+
+    for line in out.split("\n"):
+        if line.startswith(COMMIT_LOG_SEP):
+            _, commit_hash, parents = line.split(COMMIT_LOG_SEP)
+            # --diff-merges only alters merges; ordinary commits still list
+            # their files here and must not be mistaken for merge content.
+            current = commit_hash if len(parents.split()) > 1 else None
+        elif line and current:
+            mask.setdefault(current, set()).add(line)
+
+    return mask
+
+
+def _closest_parent_counts(repo_dir, wanted, window=None):
+    """{hash: {path: (additions, deletions)}} against whichever parent is nearest.
+
+    `-m` emits one numstat block per parent in a single walk, so the smallest
+    change for a path is its diff against the closest parent. That isolates what
+    the merger actually typed: first-parent counts also include the branch's own
+    work, which inflates merge churn 2.7x on repos like click.
+    """
+    out = _git_log(
+        repo_dir,
+        f"--pretty=format:{COMMIT_LOG_SEP}%H",
+        "--numstat",
+        "-m",
+        window=window,
+    )
+
+    counts = {}
+    current = None
+
+    for line in out.split("\n"):
+        if line.startswith(COMMIT_LOG_SEP):
+            current = line.split(COMMIT_LOG_SEP)[1]
+            continue
+        if not current or current not in wanted:
+            continue
+
+        fields = line.split("\t")
+        if len(fields) != 3:
+            continue
+
+        additions, deletions, filename = fields
+        path = (
+            KospexUtils.parse_git_rename_event(filename)
+            if "=>" in filename
+            else filename
+        )
+        if path not in wanted[current]:
+            continue
+
+        # Binary files report "-" rather than a count.
+        pair = (
+            int(additions) if additions != "-" else 0,
+            int(deletions) if deletions != "-" else 0,
+        )
+        seen = counts.setdefault(current, {}).get(path)
+        if seen is None or sum(pair) < sum(seen):
+            counts[current][path] = pair
+
+    return counts
+
+
+def merge_file_rows(repo_dir, window=None):
+    """Content a merge introduced that exists in none of its parents.
+
+    Returns {hash: {file_path: {"additions", "deletions", "path_change"}}}.
+
+    A merge that only combines branches authored nothing and yields no rows —
+    that is why `git log --numstat` reports zero files for it, and preserving
+    that is what stops merged work being counted twice. An "evil merge" (git's
+    term) is the exception: a conflict resolution, or a file added while
+    merging, exists in no parent and is otherwise recorded nowhere (#121).
+
+    The counting walk only runs when the mask finds something, so a repo with
+    no evil merges pays for detection alone.
+    """
+    mask = _merge_content_mask(repo_dir, window=window)
+    if not mask:
+        return {}
+
+    counts = _closest_parent_counts(repo_dir, mask, window=window)
+
+    rows = {}
+    for commit_hash, paths in mask.items():
+        for path in paths:
+            additions, deletions = counts.get(commit_hash, {}).get(path, (0, 0))
+            rows.setdefault(commit_hash, {})[path] = {
+                "additions": additions,
+                "deletions": deletions,
+                "path_change": None,
+            }
+
+    return rows
+
+
 def panopticas_version():
     """Installed panopticas package version, or None if it can't be resolved."""
     try:
@@ -330,83 +548,56 @@ class Kospex:
             if latest_datetime:
                 from_date = latest_datetime
 
-        # Use hash (#) as a delimeter as names can contain spaces
-        cmd = ["git", "log", "--pretty=format:%H#%aI#%cI#%aN#%aE#%cN#%cE", "--numstat"]
+        # The window is shared with the merge-content walks below, so both see
+        # the same commits — otherwise an incremental sync would look up merge
+        # rows for merges the main walk never emitted.
+        window = []
 
         if from_date and to_date:
-            cmd += ["--since={}".format(from_date), "--until={}".format(to_date)]
+            window += ["--since={}".format(from_date), "--until={}".format(to_date)]
             print(f"Syncing commits from {from_date} to {to_date}...")
         elif from_date:
-            cmd += ["--since={}".format(from_date)]
+            window += ["--since={}".format(from_date)]
             # print("Syncing commits from {}...".format(from_date))
             print(f"Syncing commits from {from_date}...")
         elif limit:
-            cmd += ["-n", str(limit)]
+            window += ["-n", str(limit)]
             print(f"Syncing {limit} commits...")
         else:
             print("Syncing all commits...")
 
-        result = subprocess.run(cmd, capture_output=True, text=True).stdout.split("\n")
+        # No --diff-merges here on purpose: a merge that only combines branches
+        # authored nothing, so it must contribute no file rows. Adding one would
+        # re-attribute the whole merged branch to the merge and double-count
+        # work already credited to the branch commits. Content that exists in no
+        # parent is picked up separately by merge_file_rows() below.
+        log_output = _git_log(
+            self.git.repo_dir,
+            f"--pretty=format:{COMMIT_LOG_FORMAT}",
+            "--numstat",
+            window=window,
+        )
 
-        commits = []
-        commit = {}
+        commits = parse_commit_log(log_output)
 
-        for line in result:
-            if line:
-                if "\t" in line and len(line.split("\t")) == 3:
-                    # Check if the line represents file stats
-                    additions, deletions, filename = line.split("\t")
-                    if "filenames" in commit:
-                        # The following checks for git rename events which change the filename
-                        # With a git rename event, the filename will be in the format of
-                        # old_filename => new_filename
-                        if "=>" in filename:
-                            fpath = KospexUtils.parse_git_rename_event(filename)
-                            path_change = filename
-                        else:
-                            fpath = filename
-                            path_change = None
-
-                        commit["filenames"].append(
-                            {
-                                "file_path": fpath,
-                                "path_change": path_change,
-                                "additions": int(additions) if additions != "-" else 0,
-                                "deletions": int(deletions) if deletions != "-" else 0,
-                            }
-                        )
-                elif "#" in line:
-                    if commit:  # Save the previous commit
-                        commits.append(commit)
-
-                    (
-                        hash_value,
-                        author_datetime,
-                        committer_datetime,
-                        author_name,
-                        author_email,
-                        committer_name,
-                        committer_email,
-                    ) = line.split("#", 6)
-
-                    commit = {
-                        "hash": hash_value,
-                        "author_when": author_datetime,
-                        "committer_when": committer_datetime,
-                        "author_name": author_name,
-                        "author_email": author_email.lower(),
-                        "committer_name": committer_name,
-                        "committer_email": committer_email.lower(),
-                        "filenames": [],
-                    }
-
-                else:
-                    commit["filenames"].append({"filename": line, "additions": 0, "deletions": 0})
-
-            else:
-                if commit:  # Save the last commit
-                    commits.append(commit)
-                commit = {}
+        # Content a merge introduced that exists in none of its parents --
+        # conflict resolutions, files added while merging. `git log --numstat`
+        # shows nothing for a merge, so this would otherwise land nowhere (#121).
+        # Skipped entirely when no merge carries content of its own.
+        merge_rows = merge_file_rows(self.git.repo_dir, window=window)
+        if merge_rows:
+            attached = 0
+            for commit in commits:
+                own = merge_rows.get(commit["hash"])
+                if not own:
+                    continue
+                for file_path, counts in own.items():
+                    commit["filenames"].append({"file_path": file_path, **counts})
+                    attached += 1
+            log.info(
+                "%s: %d file(s) introduced by %d merge(s) with content of their own",
+                self.git.repo_dir, attached, len(merge_rows),
+            )
 
         # cursor = conn.cursor()
 

--- a/tests/test_commit_log_parsing.py
+++ b/tests/test_commit_log_parsing.py
@@ -1,0 +1,194 @@
+"""Tests for parse_commit_log() — the commits/commit_files ingest parser.
+
+The ingest used to split git's output on "#", which is legal inside an author
+or committer name and email. One "#" shifted every later field and the last
+field absorbed the remainder, silently (#163). Real data hits this: nixpkgs has
+97 commits authored with `git#v1@kaction.cc`.
+
+The format now uses ASCII Unit Separator (\\x1f), which git rejects inside name
+and email fields, and the parser asserts the field count rather than unpacking
+optimistically — a silent shift is what kept the bug invisible.
+"""
+import os
+import subprocess
+
+import pytest
+
+from kospex_core import COMMIT_LOG_FORMAT, parse_commit_log
+
+US = "\x1f"
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "T", "GIT_AUTHOR_EMAIL": "t@e.com",
+    "GIT_COMMITTER_NAME": "T", "GIT_COMMITTER_EMAIL": "t@e.com",
+}
+
+
+def _git(cwd, *args, env=None, check=True):
+    e = {**os.environ, **_GIT_ENV, **(env or {})}
+    return subprocess.run(["git", "-C", str(cwd), *args], check=check,
+                          capture_output=True, text=True, env=e)
+
+
+def _repo(tmp_path, name="r"):
+    p = tmp_path / name
+    p.mkdir()
+    _git(p, "init", "-q", "-b", "main")
+    return p
+
+
+def _log(repo):
+    """The real ingest command, so tests exercise git's actual output."""
+    return subprocess.run(
+        ["git", "-C", str(repo), "-c", "core.quotePath=false", "log",
+         f"--pretty=format:{COMMIT_LOG_FORMAT}", "--numstat"],
+        capture_output=True, text=True, check=True).stdout
+
+
+def _record(**over):
+    f = {
+        "hash": "abc123", "author_when": "2024-01-01T00:00:00+00:00",
+        "committer_when": "2024-01-01T00:00:00+00:00", "author_name": "A",
+        "author_email": "a@e.com", "committer_name": "C",
+        "committer_email": "c@e.com", "parents": "",
+    }
+    f.update(over)
+    return US.join([f["hash"], f["author_when"], f["committer_when"],
+                    f["author_name"], f["author_email"], f["committer_name"],
+                    f["committer_email"], f["parents"]])
+
+
+def test_email_containing_hash_does_not_shift_fields():
+    """#163: the exact shape that corrupts 97 nixpkgs commits."""
+    commits = parse_commit_log(_record(author_name="KAction",
+                                       author_email="git#v1@kaction.cc",
+                                       committer_name="KAction",
+                                       committer_email="git#v1@kaction.cc"))
+
+    assert len(commits) == 1
+    c = commits[0]
+    assert c["author_email"] == "git#v1@kaction.cc"
+    assert c["committer_name"] == "KAction"
+    assert c["committer_email"] == "git#v1@kaction.cc"
+
+
+def test_name_containing_hash_does_not_shift_fields():
+    commits = parse_commit_log(_record(author_name="Bob #1"))
+
+    assert commits[0]["author_name"] == "Bob #1"
+    assert commits[0]["author_email"] == "a@e.com"
+
+
+def test_root_commit_has_zero_parents():
+    assert parse_commit_log(_record(parents=""))[0]["parents"] == 0
+
+
+def test_ordinary_commit_has_one_parent():
+    assert parse_commit_log(_record(parents="aaa"))[0]["parents"] == 1
+
+
+def test_merge_has_two_parents():
+    assert parse_commit_log(_record(parents="aaa bbb"))[0]["parents"] == 2
+
+
+def test_octopus_merge_counts_every_parent():
+    """nixpkgs has 12 octopus merges, one with 16 parents — so merge detection
+    must be `parents > 1`, never `parents == 2`."""
+    parents = " ".join(f"p{i}" for i in range(16))
+
+    assert parse_commit_log(_record(parents=parents))[0]["parents"] == 16
+
+
+def test_malformed_record_raises_rather_than_shifting():
+    truncated = US.join(["abc123", "2024-01-01T00:00:00+00:00", "A"])
+
+    with pytest.raises(ValueError):
+        parse_commit_log(truncated)
+
+
+def test_numstat_lines_become_filenames(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "a.py").write_text("x = 1\ny = 2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add")
+
+    commits = parse_commit_log(_log(repo))
+
+    assert len(commits) == 1
+    files = commits[0]["filenames"]
+    assert len(files) == 1
+    assert files[0]["file_path"] == "a.py"
+    assert files[0]["additions"] == 2
+    assert files[0]["deletions"] == 0
+
+
+def test_rename_event_is_unpacked(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "old.py").write_text("x = 1\n")
+    _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "add")
+    _git(repo, "mv", "old.py", "new.py")
+    _git(repo, "commit", "-q", "-m", "rename")
+
+    commits = parse_commit_log(_log(repo))
+    renamed = [f for c in commits for f in c["filenames"] if f.get("path_change")]
+
+    assert renamed, "expected a rename to be recorded"
+    assert renamed[0]["file_path"] == "new.py"
+    assert "=>" in renamed[0]["path_change"]
+
+
+def test_binary_file_counts_are_zero_not_dashes(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "blob.bin").write_bytes(bytes(range(256)))
+    _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "binary")
+
+    files = parse_commit_log(_log(repo))[0]["filenames"]
+
+    assert files[0]["additions"] == 0
+    assert files[0]["deletions"] == 0
+
+
+def test_merge_contributes_no_files(tmp_path):
+    """The property the whole design protects: a clean merge is bookkeeping,
+    not authorship. Regressing this double-counts every merged branch."""
+    repo = _repo(tmp_path)
+    (repo / "a.txt").write_text("a\n"); (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "base")
+    _git(repo, "checkout", "-qb", "side")
+    (repo / "b.txt").write_text("side\n"); _git(repo, "commit", "-qam", "side")
+    _git(repo, "checkout", "-q", "main")
+    (repo / "a.txt").write_text("main\n"); _git(repo, "commit", "-qam", "main")
+    _git(repo, "merge", "--no-ff", "-q", "-m", "merge side", "side")
+
+    commits = parse_commit_log(_log(repo))
+    merges = [c for c in commits if c["parents"] > 1]
+
+    assert len(merges) == 1
+    assert merges[0]["filenames"] == []
+
+
+def test_non_ascii_paths_are_unquoted(tmp_path):
+    """#116: git quotes non-ASCII paths unless core.quotePath=false."""
+    repo = _repo(tmp_path)
+    (repo / "café.py").write_text("x = 1\n")
+    _git(repo, "add", "-A"); _git(repo, "commit", "-q", "-m", "add")
+
+    files = parse_commit_log(_log(repo))[0]["filenames"]
+
+    assert files[0]["file_path"] == "café.py"
+
+
+def test_real_repo_with_hash_in_email_round_trips(tmp_path):
+    """End to end against git itself, proving git emits what the parser expects."""
+    repo = _repo(tmp_path)
+    (repo / "a.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "add",
+         env={"GIT_AUTHOR_NAME": "KAction", "GIT_AUTHOR_EMAIL": "git#v1@kaction.cc",
+              "GIT_COMMITTER_NAME": "KAction", "GIT_COMMITTER_EMAIL": "git#v1@kaction.cc"})
+
+    c = parse_commit_log(_log(repo))[0]
+
+    assert c["author_email"] == "git#v1@kaction.cc"
+    assert c["committer_email"] == "git#v1@kaction.cc"
+    assert c["author_name"] == "KAction"

--- a/tests/test_merge_file_rows.py
+++ b/tests/test_merge_file_rows.py
@@ -1,0 +1,172 @@
+"""Tests for merge_file_rows() — content a merge introduced that exists in no parent.
+
+`git log --numstat` reports zero files for a merge, which is correct: a merge
+that only combines two branches authored nothing, and attributing files to it
+would double-count work already credited to the branch commits. But it also
+hides an "evil merge" — git's own term for a merge introducing changes that
+appear in no parent (conflict resolutions, files added while merging). That
+content lands nowhere today (#121).
+
+numstat cannot express a combined diff (it silently degrades to first-parent),
+and --name-only cannot express counts, so the two are composed:
+
+    mask   --name-only --diff-merges=combined   which (merge, path) pairs qualify
+    counts --numstat -m                         one block per parent; take the min
+
+The min matters. On click, first-parent counts inflate merge churn 2.7x, because
+they include the branch's own work on those files.
+"""
+import os
+import subprocess
+
+from kospex_core import merge_file_rows
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "T", "GIT_AUTHOR_EMAIL": "t@e.com",
+    "GIT_COMMITTER_NAME": "T", "GIT_COMMITTER_EMAIL": "t@e.com",
+}
+
+
+def _git(cwd, *args, check=True):
+    return subprocess.run(["git", "-C", str(cwd), *args], check=check,
+                          capture_output=True, text=True,
+                          env={**os.environ, **_GIT_ENV})
+
+
+def _repo(tmp_path, name="r"):
+    p = tmp_path / name
+    p.mkdir()
+    _git(p, "init", "-q", "-b", "main")
+    return p
+
+
+def _commit(repo, msg):
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", msg)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_clean_merge_contributes_nothing(tmp_path):
+    """The invariant the whole design protects. Regressing this double-counts
+    every merged branch — on click it would add 4,765 rows where 442 are real."""
+    repo = _repo(tmp_path)
+    (repo / "a.txt").write_text("a\n"); (repo / "b.txt").write_text("b\n")
+    _commit(repo, "base")
+    _git(repo, "checkout", "-qb", "side")
+    (repo / "b.txt").write_text("side\n"); _commit(repo, "side")
+    _git(repo, "checkout", "-q", "main")
+    (repo / "a.txt").write_text("main\n"); _commit(repo, "main")
+    _git(repo, "merge", "--no-ff", "-q", "-m", "merge", "side")
+
+    assert merge_file_rows(str(repo)) == {}
+
+
+def test_repo_without_merges_is_empty(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "a.txt").write_text("a\n")
+    _commit(repo, "one")
+
+    assert merge_file_rows(str(repo)) == {}
+
+
+def test_repo_without_commits_is_empty(tmp_path):
+    assert merge_file_rows(str(_repo(tmp_path))) == {}
+
+
+def _evil_repo(tmp_path):
+    """A merge that resolves a conflict and adds a file of its own."""
+    repo = _repo(tmp_path)
+    (repo / "shared.txt").write_text("base\n")
+    _commit(repo, "base")
+    _git(repo, "checkout", "-qb", "side")
+    (repo / "shared.txt").write_text("side\n"); _commit(repo, "side")
+    _git(repo, "checkout", "-q", "main")
+    (repo / "shared.txt").write_text("main\n"); _commit(repo, "main")
+    _git(repo, "merge", "side", check=False)          # conflicts
+    (repo / "shared.txt").write_text("resolved\n")
+    (repo / "note.md").write_text("only here\n")
+    return repo, _commit(repo, "merge with resolution")
+
+
+def test_evil_merge_yields_its_own_content(tmp_path):
+    repo, merge = _evil_repo(tmp_path)
+
+    rows = merge_file_rows(str(repo))
+
+    assert set(rows) == {merge}
+    assert set(rows[merge]) == {"shared.txt", "note.md"}
+    assert rows[merge]["note.md"]["additions"] == 1
+    assert rows[merge]["note.md"]["deletions"] == 0
+
+
+def test_counts_use_the_closest_parent_not_the_first(tmp_path):
+    """first-parent counts credit the merger with the branch's work. Here the
+    merge result is one line from the side branch and ten lines from main."""
+    repo = _repo(tmp_path)
+    (repo / "f.txt").write_text("".join(f"{i}\n" for i in range(10)))
+    _commit(repo, "base")
+
+    _git(repo, "checkout", "-qb", "side")
+    (repo / "f.txt").write_text("".join(f"side{i}\n" for i in range(10)))
+    _commit(repo, "side rewrite")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "f.txt").write_text("".join(f"{i}\n" for i in range(9)) + "main9\n")
+    _commit(repo, "main tweak")
+
+    _git(repo, "merge", "side", check=False)
+    # Resolve to the side version, with one extra line changed.
+    (repo / "f.txt").write_text("".join(f"side{i}\n" for i in range(9)) + "resolved\n")
+    merge = _commit(repo, "resolve to side")
+
+    rows = merge_file_rows(str(repo))
+    counts = rows[merge]["f.txt"]
+
+    # vs main (parent 1) the whole file changed; vs side (parent 2) one line did.
+    assert counts["additions"] + counts["deletions"] <= 4, counts
+
+
+def test_octopus_merge_is_handled(tmp_path):
+    """nixpkgs has 12 octopus merges, one with 16 parents."""
+    repo = _repo(tmp_path)
+    (repo / "base.txt").write_text("base\n")
+    _commit(repo, "base")
+
+    for n in ("one", "two", "three"):
+        _git(repo, "checkout", "-q", "main")
+        _git(repo, "checkout", "-qb", n)
+        (repo / f"{n}.txt").write_text(f"{n}\n")
+        _commit(repo, n)
+
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "--no-ff", "-q", "-m", "octopus", "one", "two", "three")
+    (repo / "resolution.txt").write_text("added during merge\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--amend", "--no-edit")
+    merge = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    # main plus the three merged branches
+    assert len(_git(repo, "rev-list", "-1", "--parents", merge).stdout.split()) - 1 == 4
+
+    rows = merge_file_rows(str(repo))
+
+    assert merge in rows
+    assert "resolution.txt" in rows[merge]
+
+
+def test_non_ascii_paths_are_unquoted(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "shared.txt").write_text("base\n")
+    _commit(repo, "base")
+    _git(repo, "checkout", "-qb", "side")
+    (repo / "shared.txt").write_text("side\n"); _commit(repo, "side")
+    _git(repo, "checkout", "-q", "main")
+    (repo / "shared.txt").write_text("main\n"); _commit(repo, "main")
+    _git(repo, "merge", "side", check=False)
+    (repo / "shared.txt").write_text("resolved\n")
+    (repo / "café.py").write_text("x = 1\n")
+    merge = _commit(repo, "merge")
+
+    rows = merge_file_rows(str(repo))
+
+    assert "café.py" in rows[merge]


### PR DESCRIPTION
Closes #163. Closes #116. Closes #121.

Three defects in one command — `git log` at `kospex_core.py:334`.

## 1. Splitting on `#` corrupts author identity (#163)

`#` is legal in an author or committer email. One `#` shifted every later field and the last field silently absorbed the remainder. `NixOS/nixpkgs` has 97 commits authored `git#v1@kaction.cc`, which parse today as:

```
author_email     = 'git'                            <- truncated
committer_name   = 'v1@kaction.cc'                  <- an email in the name field
committer_email  = 'KAction#git#v1@kaction.cc'      <- absorbed the remainder
```

Now ASCII Unit Separator, which git rejects inside name and email fields where it permits `#`. The parser asserts the field count rather than unpacking optimistically — a silent shift is what kept this invisible.

## 2. Quoted non-ASCII paths (#116)

All walks run `-c core.quotePath=false`. `file_metadata.committer_when` is keyed on `commit_files.file_path`, so a quoted path could never match what panopticas walked.

## 3. Content a merge introduced that exists in no parent (#121)

**The main walk is unchanged — no `--diff-merges`.** A merge that only combines branches authored nothing, and attributing files to it double-counts work already credited to the branch commits. A clean merge still contributes zero rows, and there is a test pinning exactly that.

The gap is an *evil merge* — git's glossary term for "a merge that introduces changes that do not appear in any parent": a conflict resolution, or a file added while merging.

### Why two extra walks

No single git invocation both filters to combined-diff files and reports counts. Tested against a clean merge:

```
--name-only --diff-merges=combined   ->  (nothing)      correct
--numstat   --diff-merges=combined   ->  1  1  b.txt    wrong
git show -c / --cc / -m --numstat    ->  1  1  b.txt    wrong
git diff-tree -c / --cc --numstat    ->  1  1  b.txt    wrong
```

`--numstat` has no combined representation and degrades to first-parent — byte-identical, verified programmatically. So a mask walk identifies the files and a counting walk supplies numbers, and **the counting walk only runs when the mask finds something**.

### The naive fix would have inflated everything

Adding `--diff-merges=combined` to the numstat command — the shape originally proposed on #121 — attributes the whole merged branch to the merge:

| repo | rows today | this fix adds | naive fix would add |
|---|---:|---:|---:|
| kospex | 1,667 | **0** | 215 (12.9%) |
| click | 5,225 | **442** (8.5%) | 4,765 (91.2%) |
| pydantic | 25,858 | **276** (1.1%) | 418 |
| react | 131,811 | **838** (0.6%) | 22,810 (17.3%) |

### Counts come from the closest parent

`-m` emits one numstat block per parent in one walk, so the smallest change for a path is its diff against the nearest parent — what the merger actually typed:

```
src/click/shell_completion.py
  first-parent    :  40+ / 16-     <- includes the branch's work
  closest parent  :   2+ /  3-     <- the resolution
```

Across evil-merge rows, click 33% of rows differ (churn 8,469 -> 3,177) and react 29% (40,168 -> 30,971). This matters for key-person analysis, where a conflict resolution is real work by whoever knows the subsystem best.

### Cost

| | kospex (0 evil merges) | click (259) | react (357) |
|---|---:|---:|---:|
| main walk (unchanged) | 108 ms | 334 ms | 9,186 ms |
| mask | 23 ms | 92 ms | 1,850 ms |
| counts | *skipped* | 894 ms | 13,589 ms |

## `parents` populated — no migration

`[parents] INTEGER` has been declared since the Mergestat-derived schema and never written (0 of 254,997 rows). `%P` fills it. Stored as a count, and detection asks `parents > 1` — never `== 2`, since nixpkgs has an octopus merge with **16 parents**.

## Tests

20 new tests against real throwaway git repos, each watched fail first. `tests/test_commit_log_parsing.py` (13) covers the delimiter, `#` in name and email, octopus and root commits, renames, binary `-` counts, and the malformed-record raise. `tests/test_merge_file_rows.py` (7) covers the clean-merge-yields-nothing invariant, evil merges, closest-parent counts, octopus, and non-ASCII paths.

Full suite: **565 passed, 75 skipped**.

The unit tests don't exercise `sync_repo`, so I also ran it end to end against a throwaway repo and DB:

```
author_email intact      : 'git#v1@kaction.cc'
committer_name           : 'KAction'
clean merge parents      : 2      nulls remaining: 0
clean merge file rows    : 0      <- the invariant
evil merge paths         : ['café.py', 'shared.txt']
quoted paths in DB       : 0
```

## Backfill is NOT included

All three fixes apply to newly-synced commits only, and commit sync is incremental (`--since` the last recorded commit), so existing rows are untouched. Measured against the live 665 MB database:

- **#163: 0 rows affected.** No commit in the DB carries the corruption signature (`committer_email` containing `#`). nixpkgs is not synced there. This fix is preventive.
- **#116: 34 rows across 4 repos** (react, mkdocs, express, ghp-import), 11 distinct paths. Unquoting changes `file_path`, part of `PRIMARY KEY(hash, file_path, _repo_id)`, so a re-sync **adds** the unquoted row rather than replacing the quoted one — these need deleting, not just re-syncing.
- **`parents`: NULL on all 254,997 rows** until re-sync. Consumers must treat NULL as unknown, not as "not a merge".

Filed separately with a detection query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
