### PR TITLE
feat(kreaper): add delete-repo -dry-run and drop the stale warning

### DIFF
--- a/changes/202608-kreaper-dry-run.md
+++ b/changes/202608-kreaper-dry-run.md
@@ -1,0 +1,75 @@
+# kreaper delete-repo: -dry-run, and drop the stale warning
+
+Supports the backfill sequence in #165: detect → `kreaper delete-repo` → re-sync.
+
+## Overview
+
+`kreaper delete-repo -repo_id <id>` is the supported way to reset a repo before
+a full re-sync. It had two problems that made it hard to trust:
+
+1. It printed `Warning : This function only implements table!` on **every**
+   invocation, including the `-repo_id` path that demonstrably clears every repo
+   table. The accompanying `# TODO - Implement for all tables!` was stale.
+2. There was no way to see what it would delete before deleting it.
+
+## Why delete-repo resets a re-sync
+
+`delete_repo()` iterates `get_repo_tables()` — every table carrying a `_repo_id`
+column, auto-detected via PRAGMA rather than hardcoded, so a future table is
+covered without touching kreaper. Against the current schema that is 13 tables:
+
+```
+branch_history  branches      commit_files   commit_metadata  commits
+dependency_data developer_stats file_metadata kospex_groups   krunner
+observations    repo_hotspots  repos
+```
+
+`repos` is included, so `last_sync_hash` and the sync provenance go with it.
+`sync_repo()` then finds no prior `MAX(committer_when)`, leaves `from_date`
+unset, and walks the full history. That is what makes a re-sync actually
+reconstruct data rather than resume from the last commit.
+
+That behaviour was already correct — it was only the warning that said otherwise.
+
+## Change
+
+`-dry-run` reports the row counts per table and deletes nothing:
+
+```
+$ kreaper delete-repo -repo_id github.com~c-w~ghp-import -dry-run
+Dry run - would delete the following for repo_id github.com~c-w~ghp-import:
+
+  commit_files              191 rows
+  commits                   139 rows
+  developer_stats            24 rows
+  file_metadata              19 rows
+  repos                       1 rows
+
+  TOTAL                     374 rows
+
+Nothing deleted. Re-run with -yes to delete.
+```
+
+It deliberately does **not** require `-yes`: the dry run writes nothing, and
+demanding the destructive confirmation flag to see a preview just trains people
+to type it.
+
+Counts come from `Kospex.repo_id_row_counts()`, which walks the same
+`get_repo_tables()` list the delete does — so the preview cannot drift from the
+deletion. Tables with no rows are omitted; a repo touches a handful of the 13,
+and listing the empty ones is noise.
+
+## Files changed
+
+- `src/kospex_core.py` — `repo_id_row_counts()`
+- `src/kreaper.py` — `-dry-run`, stale warning removed, docstring explains the
+  provenance reset
+- `tests/test_kreaper_dry_run.py` — 9 tests
+
+## Notes
+
+- The command help now states that `repos` is cleared and what that means for
+  the next sync, since that is the non-obvious part and the reason the command
+  matters for #165.
+- `test_delete_still_deletes` seeds a second repo and asserts it survives, so
+  the delete stays scoped to one `_repo_id`.

--- a/src/kospex_core.py
+++ b/src/kospex_core.py
@@ -21,7 +21,7 @@ from rich.table import Table as RichTable
 
 import kospex_schema as KospexSchema
 import kospex_utils as KospexUtils
-from kospex.db.introspect import get_kospex_tables
+from kospex.db.introspect import get_kospex_tables, get_repo_tables
 from kospex_dependencies import KospexDependencies
 from kospex_git import KospexGit, MissingGitDirectory
 from kospex_query import KospexData, KospexQuery
@@ -1578,6 +1578,26 @@ class Kospex:
         table = KospexUtils.get_keyvalue_table(config)
 
         return table
+
+    def repo_id_row_counts(self, repo_id):
+        """{table: row_count} for every repo table holding rows for repo_id.
+
+        Tables with no rows are omitted — a repo touches a handful of the repo
+        tables, and listing the empty ones is noise in a confirmation prompt.
+
+        Read-only. Backs `kreaper delete-repo -dry-run`, so what gets counted
+        here and what gets deleted there come from the same table list.
+        """
+        counts = {}
+
+        for table in sorted(get_repo_tables(self.kospex_db)):
+            row = self.kospex_db.execute(
+                f"SELECT COUNT(*) FROM [{table}] WHERE _repo_id = ?", [repo_id]
+            ).fetchone()
+            if row and row[0]:
+                counts[table] = row[0]
+
+        return counts
 
     def delete_repo_id_from_table(self, table, repo_id):
         """

--- a/src/kreaper.py
+++ b/src/kreaper.py
@@ -30,11 +30,30 @@ def repo_ids():
 @click.option('-repo_id', type=click.STRING)
 @click.option('-table', type=click.STRING, help="Only delete rows with repo_id elements from this table.")
 @click.option('-yes/-no', default=False)
-def delete_repo(repo_id,table,yes):
-    """ Delete a repo_id from all tables."""
+@click.option('-dry-run', 'dry_run', is_flag=True,
+              help="Show the rows that would be deleted, without deleting them.")
+def delete_repo(repo_id,table,yes,dry_run):
+    """ Delete a repo_id from all tables.
 
-    # TODO - Implement for all tables!
-    print("Warning : This function only implements table!")
+    Clears the repo from every table carrying a _repo_id column, detected at
+    runtime rather than hardcoded. That includes 'repos', so the sync
+    provenance goes too and the next sync walks the full history - which is
+    what makes this the way to reset a repo before a re-sync.
+
+    Use -dry-run first to see the row counts per table.
+    """
+    if dry_run and repo_id:
+        counts = kospex.repo_id_row_counts(repo_id)
+        if not counts:
+            print(f"No rows found for repo_id {repo_id}")
+            return
+
+        print(f"Dry run - would delete the following for repo_id {repo_id}:\n")
+        for name in sorted(counts):
+            print(f"  {name:<20} {counts[name]:>8} rows")
+        print(f"\n  {'TOTAL':<20} {sum(counts.values()):>8} rows")
+        print("\nNothing deleted. Re-run with -yes to delete.")
+        return
 
     if table:
         if table in get_kospex_tables(kospex.kospex_db):

--- a/tests/test_kreaper_dry_run.py
+++ b/tests/test_kreaper_dry_run.py
@@ -1,0 +1,169 @@
+"""Tests for `kreaper delete-repo -dry-run` and the counts behind it.
+
+delete-repo clears a repo from every table carrying a _repo_id column, which
+includes `repos` — so the sync provenance goes too and the next sync walks full
+history. That makes it the supported way to reset a repo before a re-sync, and
+a destructive operation worth being able to inspect first.
+"""
+import os
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def kospex_env(tmp_path, monkeypatch):
+    """A throwaway KOSPEX_HOME + DB. Kospex() connects on construction, so the
+    env has to be set before it is built."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("KOSPEX_HOME", str(home))
+    monkeypatch.setenv("KOSPEX_DB", str(home / "kospex.db"))
+    monkeypatch.setenv("KOSPEX_CODE", str(tmp_path / "code"))
+    from kospex.habitat_config import HabitatConfig
+    HabitatConfig.reset_instance()
+    yield home
+    HabitatConfig.reset_instance()
+
+
+def _seed(kospex, repo_id="github.com~acme~demo", other="github.com~acme~other"):
+    """Rows in three repo tables, plus a second repo that must survive."""
+    import kospex_schema as KospexSchema
+
+    kospex.kospex_db.table(KospexSchema.TBL_COMMITS).upsert_all([
+        {"hash": "a1", "_repo_id": repo_id, "author_email": "a@e.com"},
+        {"hash": "a2", "_repo_id": repo_id, "author_email": "a@e.com"},
+        {"hash": "b1", "_repo_id": other, "author_email": "b@e.com"},
+    ], pk=["_repo_id", "hash"])
+
+    kospex.kospex_db.table(KospexSchema.TBL_COMMIT_FILES).upsert_all([
+        {"hash": "a1", "file_path": "x.py", "_repo_id": repo_id},
+        {"hash": "a1", "file_path": "y.py", "_repo_id": repo_id},
+        {"hash": "a1", "file_path": "z.py", "_repo_id": repo_id},
+        {"hash": "b1", "file_path": "q.py", "_repo_id": other},
+    ], pk=["hash", "file_path", "_repo_id"])
+
+    kospex.kospex_db.table(KospexSchema.TBL_REPOS).upsert_all([
+        {"_repo_id": repo_id, "last_sync_hash": "deadbeef"},
+        {"_repo_id": other, "last_sync_hash": "cafe"},
+    ], pk=["_repo_id"])
+
+    return repo_id, other
+
+
+def test_counts_report_rows_per_table(kospex_env):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    counts = k.repo_id_row_counts(repo_id)
+
+    assert counts["commits"] == 2
+    assert counts["commit_files"] == 3
+    assert counts["repos"] == 1
+
+
+def test_counts_omit_tables_with_no_rows(kospex_env):
+    """A repo touches a handful of the 13 repo tables; listing the empty ones
+    is noise in a confirmation prompt."""
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    counts = k.repo_id_row_counts(repo_id)
+
+    assert all(v > 0 for v in counts.values())
+    assert "file_metadata" not in counts
+
+
+def test_counts_for_unknown_repo_are_empty(kospex_env):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    _seed(k)
+
+    assert k.repo_id_row_counts("github.com~nobody~nothing") == {}
+
+
+def test_counts_do_not_include_another_repo(kospex_env):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, other = _seed(k)
+
+    assert k.repo_id_row_counts(repo_id)["commits"] == 2
+    assert k.repo_id_row_counts(other)["commits"] == 1
+
+
+def _run(monkeypatch, kospex, args):
+    import kreaper
+    monkeypatch.setattr(kreaper, "kospex", kospex)
+    return CliRunner().invoke(kreaper.cli, args)
+
+
+def test_dry_run_deletes_nothing(kospex_env, monkeypatch):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    result = _run(monkeypatch, k, ["delete-repo", "-repo_id", repo_id, "-dry-run"])
+
+    assert result.exit_code == 0
+    assert k.repo_id_row_counts(repo_id)["commits"] == 2
+    assert k.repo_id_row_counts(repo_id)["commit_files"] == 3
+
+
+def test_dry_run_reports_what_would_go(kospex_env, monkeypatch):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    result = _run(monkeypatch, k, ["delete-repo", "-repo_id", repo_id, "-dry-run"])
+
+    assert "commits" in result.output
+    assert "commit_files" in result.output
+    assert "6" in result.output, "expected a total row count"
+
+
+def test_dry_run_does_not_require_yes(kospex_env, monkeypatch):
+    """-dry-run writes nothing, so demanding the destructive confirmation flag
+    would just train people to type it."""
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    result = _run(monkeypatch, k, ["delete-repo", "-repo_id", repo_id, "-dry-run"])
+
+    assert result.exit_code == 0
+    assert "Please specify -yes" not in result.output
+
+
+def test_delete_still_deletes(kospex_env, monkeypatch):
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, other = _seed(k)
+
+    result = _run(monkeypatch, k, ["delete-repo", "-repo_id", repo_id, "-yes"])
+
+    assert result.exit_code == 0
+    assert k.repo_id_row_counts(repo_id) == {}
+    assert k.repo_id_row_counts(other)["commits"] == 1, "other repo must survive"
+
+
+def test_no_stale_not_implemented_warning(kospex_env, monkeypatch):
+    """The -repo_id path does clear every repo table; the old warning claimed
+    otherwise on every invocation and put people off using it."""
+    from kospex_core import Kospex
+
+    k = Kospex()
+    repo_id, _ = _seed(k)
+
+    result = _run(monkeypatch, k, ["delete-repo", "-repo_id", repo_id, "-dry-run"])
+
+    assert "only implements table" not in result.output


### PR DESCRIPTION
Supports the backfill sequence in #165: detect → `kreaper delete-repo` → re-sync.

## Two problems with `delete-repo`

**A stale warning that contradicted the code.** It printed this on *every* invocation, including the `-repo_id` path:

```
Warning : This function only implements table!
# TODO - Implement for all tables!
```

The TODO is stale. `delete_repo()` iterates `get_repo_tables()` — every table carrying a `_repo_id` column, auto-detected via PRAGMA rather than hardcoded, so a future table is covered without touching kreaper. Against the current schema that is 13 tables:

```
branch_history  branches       commit_files   commit_metadata  commits
dependency_data developer_stats file_metadata kospex_groups    krunner
observations    repo_hotspots  repos
```

The warning was misleading enough to put someone off using a command that works.

**No way to preview a destructive operation.**

## Why this command matters for #165

`repos` is in that list, so `last_sync_hash` and the sync provenance are cleared too. `sync_repo()` then finds no prior `MAX(committer_when)`, leaves `from_date` unset, and walks the full history.

That is what makes a re-sync actually *reconstruct* data rather than resume from the last commit — and it removes the need for the `--from-date` mechanism I speculated about on #165. The behaviour was already correct; only the warning said otherwise.

## `-dry-run`

Verified against the live 665 MB database (read-only, nothing deleted):

```
$ kreaper delete-repo -repo_id github.com~c-w~ghp-import -dry-run
Dry run - would delete the following for repo_id github.com~c-w~ghp-import:

  commit_files              191 rows
  commits                   139 rows
  developer_stats            24 rows
  file_metadata              19 rows
  repos                       1 rows

  TOTAL                     374 rows

Nothing deleted. Re-run with -yes to delete.
```

It deliberately does **not** require `-yes`. The dry run writes nothing, and demanding the destructive confirmation flag to see a preview only trains people to type it.

Counts come from `Kospex.repo_id_row_counts()`, which walks the same `get_repo_tables()` list the delete does — so the preview cannot drift from the deletion. Tables with no rows are omitted; a repo touches a handful of the 13 and listing the empty ones is noise in a confirmation prompt.

## Tests

9 new tests in `tests/test_kreaper_dry_run.py`, each watched fail first:

- counts per table, empty tables omitted, unknown repo returns `{}`
- counts scoped to one `_repo_id` and not another
- `-dry-run` deletes nothing, reports the tables and a total, and does not require `-yes`
- `-yes` still deletes, and a second seeded repo survives
- the stale warning is gone

Full suite: **574 passed, 75 skipped**.

## Not in scope

The detection command (`kospex doctor`) from #165 — this PR only makes the repair half trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
